### PR TITLE
refactor: #13

### DIFF
--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -22,7 +22,7 @@ class NoteController extends Controller
      */
     public function create(Note $note, Tag $tag, Testament $testament)
     {
-        return view('notes.create')->with(['tags' => $tag->get(), 'testaments' => $testament->get()]);
+        return view('notes.create')->with(['tags'=>$tag->get(), 'testaments'=>$testament->get()]);
     }
     
     /**

--- a/app/Models/Answer.php
+++ b/app/Models/Answer.php
@@ -12,8 +12,24 @@ class Answer extends Model
     /**
      * Questionモデルとのリレーションシップ
      */
-     public function questions()
+     public function question()
      {
-         $this->belongsTo
+         return $this->belongsTo(Question::class);
      }
+     
+     /**
+      * Testamentモデルとのリレーションシップ
+      */
+      public function testaments()
+      {
+          return $this->belongsToMany(Testament::class);
+      }
+      
+      /**
+      * Userモデルとのリレーションシップ
+      */
+      public function user()
+      {
+          return $this->belongsTo(User::class);
+      }
 }

--- a/app/Models/Answer.php
+++ b/app/Models/Answer.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Answer extends Model
+{
+    use HasFactory;
+    
+    /**
+     * Questionモデルとのリレーションシップ
+     */
+     public function questions()
+     {
+         $this->belongsTo
+     }
+}

--- a/app/Models/Color.php
+++ b/app/Models/Color.php
@@ -8,4 +8,12 @@ use Illuminate\Database\Eloquent\Model;
 class Color extends Model
 {
     use HasFactory;
+    
+    /**
+     * Tagモデルとのリレーションシップ
+     */
+     public function tags()
+     {
+         return $this->hasMany(Tag::class);
+     }
 }

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -8,4 +8,20 @@ use Illuminate\Database\Eloquent\Model;
 class Comment extends Model
 {
     use HasFactory;
+    
+    /**
+     * Noteモデルとのリレーションシップ
+     */
+     public function note()
+     {
+         return $this->belongsTo(Note::class);
+     }
+     
+     /**
+      * Userモデルとのリレーションシップ
+      */
+      public function user()
+      {
+          return $this->belongsTo(User::class);
+      }
 }

--- a/app/Models/Connection.php
+++ b/app/Models/Connection.php
@@ -8,4 +8,12 @@ use Illuminate\Database\Eloquent\Model;
 class Connection extends Model
 {
     use HasFactory;
+    
+    /**
+     * Userモデルとのリレーションシップ
+     */
+     public function user()
+     {
+         return $this->belongsTo(User::class);
+     }
 }

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -31,4 +31,20 @@ class Note extends Model
      {
          return $this->belongsToMany(Tag::class);
      }
+     
+     /**
+      * Commentモデルとのリレーションシップ
+      */
+      public function comments()
+     {
+         return $this->hasMany(Comment::class);
+     }
+     
+     /**
+      * Userモデルとのリレーションシップ
+      */
+      public function user()
+      {
+          return $this->belongsTo(User::class);
+      }
 }

--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -8,4 +8,36 @@ use Illuminate\Database\Eloquent\Model;
 class Question extends Model
 {
     use HasFactory;
+    
+    /**
+     * Answerモデルとのリレーションシップ
+     */
+     public function answers()
+     {
+         return $this->hasMany(Answer::class);
+     }
+     
+     /**
+      * Tagモデルとのリレーションシップ
+      */
+      public function tags()
+      {
+          return $this->belongsToMany(Tag::class);
+      }
+      
+      /**
+       * Testamentモデルとのリレーションシップ
+       */
+       public function testaments()
+      {
+          return $this->belongsToMany(Testament::class);
+      }
+      
+      /**
+      * Userモデルとのリレーションシップ
+      */
+      public function user()
+      {
+          return $this->belongsTo(User::class);
+      }
 }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -16,4 +16,20 @@ class Tag extends Model
      {
          return $this->belongsToMany(Testament::class);
      }
+     
+     /**
+      * Questionモデルとのリレーションシップ
+      */
+      public function questions()
+      {
+          return $this->belongsToMany(Question::class);
+      }
+      
+      /**
+       * Colorモデルとのリレーションシップ
+       */
+       public function color()
+       {
+          return $this->belongsTo(Color::class);
+       }
 }

--- a/app/Models/Testament.php
+++ b/app/Models/Testament.php
@@ -24,4 +24,20 @@ class Testament extends Model
     {
         return $this->belongsToMany(Note::class);
     }
+    
+    /**
+     * Questionモデルとのリレーションシップ
+     */
+     public function questions()
+     {
+         return $this->belongsToMany(Question::class);
+     }
+     
+     /**
+      * Answerモデルとのリレーションシップ
+      */
+      public function answers()
+     {
+         return $this->belongsToMany(Answer::class);
+     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -41,4 +41,44 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+    
+    /**
+     * Connectionモデルとのリレーションシップ
+     */
+     public function connections()
+     {
+         return $this->hasMany(Connection::class);
+     }
+    
+    /**
+     * Noteモデルとのリレーションシップ
+     */
+     public function notes()
+     {
+         return $this->hasMany(Note::class);
+     }
+     
+     /**
+     * Commentモデルとのリレーションシップ
+     */
+     public function comments()
+     {
+         return $this->hasMany(Comment::class);
+     }
+     
+     /**
+     * Answerモデルとのリレーションシップ
+     */
+     public function answers()
+     {
+         return $this->hasMany(Answer::class);
+     }
+     
+     /**
+     * Questionモデルとのリレーションシップ
+     */
+     public function questions()
+     {
+         return $this->hasMany(Question::class);
+     }
 }

--- a/database/migrations/2023_11_28_181130_drop_comment_note_table.php
+++ b/database/migrations/2023_11_28_181130_drop_comment_note_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::dropIfExists('comment_note');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+};

--- a/database/migrations/2023_11_28_181311_drop_comment_question_table.php
+++ b/database/migrations/2023_11_28_181311_drop_comment_question_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::dropIfExists('comment_question');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+};

--- a/database/migrations/2023_11_28_181420_add_note_id_to_comments_table.php
+++ b/database/migrations/2023_11_28_181420_add_note_id_to_comments_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->foreignId('note_id')->constrained()->onDelete('cascade')->onUpdate('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2023_11_28_181744_create_answers_table.php
+++ b/database/migrations/2023_11_28_181744_create_answers_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('answers', function (Blueprint $table) {
+            $table->id();
+            $table->text('text');
+            $table->foreignId('user_id')->constrained()->onDelete('cascade')->onUpdate('cascade');
+            $table->foreignId('question_id')->constrained()->onDelete('cascade')->onUpdate('cascade');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('answers');
+    }
+};

--- a/database/migrations/2023_11_28_181804_create_answer_testament_table.php
+++ b/database/migrations/2023_11_28_181804_create_answer_testament_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('answer_testament', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('answer_id')->constrained()->onDelete('cascade')->onUpdate('cascade');
+            $table->foreignId('testament_id')->constrained()->onDelete('cascade')->onUpdate('cascade');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('answer_testament');
+    }
+};

--- a/database/migrations/2023_11_28_182144_create_question_tag_table.php
+++ b/database/migrations/2023_11_28_182144_create_question_tag_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('question_tag', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('question_id')->constrained()->onDelete('cascade')->onUpdate('cascade');
+            $table->foreignId('tag_id')->constrained()->onDelete('cascade')->onUpdate('cascade');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('question_tag');
+    }
+};


### PR DESCRIPTION
## 概要
いくつかのデータベース構造の修正に基づき、マイグレーションを実行する。

notesテーブルとcommentsテーブルが多対多の関係にあったため、これを1対多の関係にしたい:
-notesテーブルとcommentsテーブルの中間テーブルを削除する。
-同様に、questionsテーブルとcommentsテーブルの中間テーブルも削除する。

commentsテーブルがnotesテーブルとquestionsテーブル両方のコメントを持つような構造であったが、これをそれぞれのテーブルについて分割する:
-commetsテーブルをnotesテーブルのコメントをinsertするために活用する。
-questionsテーブルのコメントをinsertするテーブルを新たに作成する。commentsテーブルとの名称の重複を避けるため、answersテーブルとする。
-新しく作ったテーブルについてモデルを作成する。

## 変更点
既存のテーブルのうち、削除するテーブルについてマイグレーションファイルを作成する。
php artisan make:migration drop_comment_note_table
php artisan make:migration drop_comment_question_table

upメソッドに次を追加：
Schema::dropIfExists('tableName');

新規テーブル作成の及び特定のテーブルにカラム追加
php artisan make:migration add_note_id_to_comments_table --table=comments

質問の回答をinsertするため、answersテーブルを作成。answersテーブルとtestamentsテーブルのリレーションシップも定義するため、中間テーブルを作成。
php artisan make:migration create_answers_table
php artisan make:migration create_answer_testament_table

questionが複数のtagを持てるようにするため、中間テーブルを作成
php artisan make:migration create_question_tag_table

answersテーブルのモデルAnswerを作成
php artisan make:model Answer

## 動作確認
なし

## その他
モデルのメソッドを追加して、すべてのテーブルのリレーションシップを実装した

以下の変更箇所が消えていたので、別のブランチで修正したい
UserモデルとConnectionモデルのリレーションシップメソッド
