### PR TITLE
feat #10 publish settings

### DIFF
--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -22,7 +22,9 @@ class NoteController extends Controller
      */
     public function create(Note $note, Tag $tag, Testament $testament)
     {
-        return view('notes.create')->with(['tags'=>$tag->get(), 'testaments'=>$testament->get()]);
+        $value = 'true';
+        
+        return view('notes.create')->with(['value' => $value, 'tags'=>$tag->get(), 'testaments'=>$testament->get()]);
     }
     
     /**

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -19,6 +19,7 @@ class NoteController extends Controller
     
     /**
      * ノート作成画面
+     * $valueは、ラジオボタンのchecked属性を動的に制御するために用意
      */
     public function create(Note $note, Tag $tag, Testament $testament)
     {
@@ -30,10 +31,9 @@ class NoteController extends Controller
     /**
      * リクエストされたデータをnotesテーブルにinsertする
      */
-     
      public function store(Request $request, Note $note)
      {
-         $input = $request['post'];
+         $input = $request['note'];
          $input += ['user_id' => $request->user()->id];
          $post = fill($input)->save();
          return redirect(route('notes.index'));

--- a/resources/views/notes/create.blade.php
+++ b/resources/views/notes/create.blade.php
@@ -8,22 +8,30 @@
         <form action="/notes" method="POST">
             @csrf
             <div class="testament">
+                <label>
+                    <input type="radio" value="1" name="note[public]" {{ $value == true ? 'checked' : '' }}>
+                    公開
+                </label>
+                <label>
+                    <input type="radio" value="0" name="note[public]" {{ $value == false ? 'checked' : '' }}>
+                    非公開
+                </label>
+                <br>
                 <h2>聖句</h2>
                 @foreach ($testaments as $testament)
                     <lavel>
                         <input type="checkbox" value={{ $testament->id }} name="testaments_array[]">
                             {{ $testament->text }}
-                        </input>
                     </lavel>
                 @endforeach
             </div>
             <div class="title">
                 <h2>タイトル</h2>
-                <input type="text" name="note[title]">
+                <input type="text" name="note[title]" placeholder="タイトル">
             </div>
             <div class="text">
                 <h2>本文</h2>
-                <textarea name="note[text]"></textarea>
+                <textarea name="note[text]" placeholder="ここにノートを入力"></textarea>
             </div>
             
             <div class="tag">
@@ -32,7 +40,6 @@
                     <lavel>
                         <input type="checkbox" value={{ $tag->id }} name="tags_array[]">
                             {{ $tag->tag }}
-                        </input>
                     </lavel>
                 @endforeach
             </div>

--- a/resources/views/notes/create.blade.php
+++ b/resources/views/notes/create.blade.php
@@ -10,11 +10,11 @@
             <div class="testament">
                 <label>
                     <input type="radio" value="1" name="note[public]" {{ $value == true ? 'checked' : '' }}>
-                    公開
+                    公開ノート
                 </label>
                 <label>
                     <input type="radio" value="0" name="note[public]" {{ $value == false ? 'checked' : '' }}>
-                    非公開
+                    非公開ノート
                 </label>
                 <br>
                 <h2>聖句</h2>
@@ -23,6 +23,7 @@
                         <input type="checkbox" value={{ $testament->id }} name="testaments_array[]">
                             {{ $testament->text }}
                     </lavel>
+                    <br>
                 @endforeach
             </div>
             <div class="title">


### PR DESCRIPTION
## 概要
notesテーブルにinsertするノートの作成画面を作ったが、カラムの一つであるpublicを選択できない状態だった。
そのため、bladeファイルに変更を加えた。

## 変更点
/notes/create.blade.phpに、1か0をフォームから送信できるようにするinput要素を加えた。type属性はラジオボタン。プロパティとchecked属性を含んだ条件式で、どちらの値を送信するか指定する。プロパティはコントローラに定義した。

## 動作確認
php artisan serveで適切に表示されていることを確認