### PR TITLE
refactor: #16 Saving and editing notes

### DIFF
--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -32,16 +32,21 @@ class NoteController extends Controller
     
     /**
      * ノート作成画面
-     * $valueは、ラジオボタンのchecked属性を動的に制御するために用意
+     * $public_valueは、ラジオボタンのchecked属性を動的に制御するために用意
      */
     public function create(Tag $tag, Testament $testament)
     {
-        $value = 'true';
+        $public_value = 'true';
         
-        return view('notes.create')->with(['value' => $value, 'tags'=>$tag->get(), 'testaments'=>$testament->get()]);
+        return view('notes.create')->with([
+            'public_value' => $public_value,
+            'tags' => $tag->get(),
+            'testaments' => $testament->get(),
+            ]);
     }
     
     /**
+     * ノート保存処理
      * リクエストされたデータをnotesテーブルにinsertする
      */
      public function store(Note $note, NoteRequest $request)
@@ -57,4 +62,32 @@ class NoteController extends Controller
          $note->tags()->attach($input_tags);
          return redirect(route('notes.index'));
      }
+     
+     /**
+      * ノート編集画面
+      */
+      public function edit(Note $note, Tag $tag, Testament $testament)
+      {
+          $public_value = $note->public;
+          // pluckメソッドでidカラムの値を抽出
+          $testament_id = $note->testaments->pluck('id');
+          $tag_id = $note->tags->pluck('id');
+          
+          return view('notes.edit')->with([
+              'public_value' => $public_value,
+              'testament_id' => $testament_id,
+              'tag_id' => $tag_id,
+              'note' => $note,
+              'tags' => $tag->get(),
+              'testaments' => $testament->get(),
+              ]);
+      }
+      
+     /**
+      * ノート更新処理
+      */
+      public function update()
+      {
+          //
+      }
 }

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -21,7 +21,7 @@ class NoteController extends Controller
      * ノート作成画面
      * $valueは、ラジオボタンのchecked属性を動的に制御するために用意
      */
-    public function create(Note $note, Tag $tag, Testament $testament)
+    public function create(Tag $tag, Testament $testament)
     {
         $value = 'true';
         
@@ -31,11 +31,17 @@ class NoteController extends Controller
     /**
      * リクエストされたデータをnotesテーブルにinsertする
      */
-     public function store(Request $request, Note $note)
+     public function store(Request $request, Note $note )
      {
-         $input = $request['note'];
-         $input += ['user_id' => $request->user()->id];
-         $post = fill($input)->save();
+         $input_note = $request['note'];
+         $input_testaments = $request->testaments_array;
+         $input_tags = $request->tags_array;
+         
+         $input_note += ['user_id' => $request->user()->id]; // user():requestを送信したユーザーの情報を取得するRequestメソッド
+         $note->fill($input_note)->save();
+         // attachメソッドを使って中間テーブルにデータを保存
+         $note->testaments()->attach($input_testaments);
+         $note->tags()->attach($input_tags);
          return redirect(route('notes.index'));
      }
 }

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Models\Note;
 use App\Models\Tag;
 use App\Models\Testament;
+use App\Http\Requests\NoteRequest;
 
 class NoteController extends Controller
 {
@@ -16,6 +17,18 @@ class NoteController extends Controller
     {
         return view('notes.index')->with(['notes' => $note->get()]);
     }
+    
+    /**
+     * ノート詳細画面
+     * 特定idのノートを表示する
+     * 
+     * $param Object Note
+     * return Response note view
+     */
+     public function show(Note $note)
+     {
+         return view('notes.show')->with(['note' => $note]);
+     }
     
     /**
      * ノート作成画面
@@ -31,7 +44,7 @@ class NoteController extends Controller
     /**
      * リクエストされたデータをnotesテーブルにinsertする
      */
-     public function store(Request $request, Note $note )
+     public function store(Note $note, NoteRequest $request)
      {
          $input_note = $request['note'];
          $input_testaments = $request->testaments_array;

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -57,9 +57,11 @@ class NoteController extends Controller
          
          $input_note += ['user_id' => $request->user()->id]; // user():requestを送信したユーザーの情報を取得するRequestメソッド
          $note->fill($input_note)->save();
+         
          // attachメソッドを使って中間テーブルにデータを保存
          $note->testaments()->attach($input_testaments);
          $note->tags()->attach($input_tags);
+         
          return redirect(route('notes.index'));
      }
      
@@ -86,8 +88,19 @@ class NoteController extends Controller
      /**
       * ノート更新処理
       */
-      public function update()
+      public function update(Note $note, NoteRequest $request)
       {
-          //
+          $input_note = $request['note'];
+          $input_testaments = $request->testaments_array;
+          $input_tags = $request->tags_array;
+         
+          $input_note += ['user_id' => $request->user()->id]; // user():requestを送信したユーザーの情報を取得するRequestメソッド
+          $note->fill($input_note)->save();
+          
+          // 関連データを更新するために sync() メソッドを使用する
+          $note->testaments()->sync($input_testaments);
+          $note->tags()->sync($input_tags);
+          
+          return redirect('/notes/' . $note->id);
       }
 }

--- a/app/Http/Requests/NoteRequest.php
+++ b/app/Http/Requests/NoteRequest.php
@@ -13,7 +13,7 @@ class NoteRequest extends FormRequest
      */
     public function authorize()
     {
-        return false;
+        return true; //元の値はfalse
     }
 
     /**
@@ -24,7 +24,9 @@ class NoteRequest extends FormRequest
     public function rules()
     {
         return [
-            //
+            'note.public' => 'required',
+            'note.title' => 'required|string|max:200',
+            'note.text' => 'required',
         ];
     }
 }

--- a/app/Http/Requests/NoteRequest.php
+++ b/app/Http/Requests/NoteRequest.php
@@ -24,8 +24,7 @@ class NoteRequest extends FormRequest
     public function rules()
     {
         return [
-            'note.public' => 'required',
-            'note.title' => 'required|string|max:200',
+            'note.title' => 'required',
             'note.text' => 'required',
         ];
     }

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -14,6 +14,8 @@ class Note extends Model
         'text',
         'user_id',
         'public',
+        'created_at',
+        'updated_at',
         ];
     
     /**

--- a/database/migrations/2023_11_30_205444_remove_tag_id_from_notes_table.php
+++ b/database/migrations/2023_11_30_205444_remove_tag_id_from_notes_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('notes', function (Blueprint $table) {
+            // dropForeignメソッドで外部キーを除外
+            // (外部キー名は{テーブル名}_{カラム名}_foreign)
+            $table->dropForeign('notes_tag_id_foreign');
+            $table->dropColumn('tag_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('notes', function (Blueprint $table) {
+            $table->foreignId('tag_id')->constrained()->onDelete('cascade')->onUpdate('cascade');
+        });
+    }
+};

--- a/database/seeders/NoteSeeder.php
+++ b/database/seeders/NoteSeeder.php
@@ -19,7 +19,6 @@ class NoteSeeder extends Seeder
         DB::table('notes')->insert([
             'title' => 'テスト',
             'text' => 'これはテストノートです。うまくいくかな。',
-            'tag_id' => 1,
             'user_id' => 1,
             'public' => 1,
             'created_at' => new DateTime(),

--- a/resources/views/notes/create.blade.php
+++ b/resources/views/notes/create.blade.php
@@ -9,11 +9,11 @@
             @csrf
             <div class="testament">
                 <label>
-                    <input type="radio" value="1" name="note[public]" {{ $value == true ? 'checked' : '' }}>
+                    <input type="radio" value="1" name="note[public]" {{ $public_value == true ? 'checked' : '' }}>
                     公開ノート
                 </label>
                 <label>
-                    <input type="radio" value="0" name="note[public]" {{ $value == false ? 'checked' : '' }}>
+                    <input type="radio" value="0" name="note[public]" {{ $public_value == false ? 'checked' : '' }}>
                     非公開ノート
                 </label>
                 <br>

--- a/resources/views/notes/create.blade.php
+++ b/resources/views/notes/create.blade.php
@@ -20,7 +20,7 @@
                 <h2>聖句</h2>
                 @foreach ($testaments as $testament)
                     <lavel>
-                        <input type="checkbox" value={{ $testament->id }} name="testaments_array[]">
+                        <input type="checkbox" value={{ $testament->id }} name="testaments_array[]" {{ in_array($testament->id, old('testaments_array', [])) ? 'checked' : '' }}>
                             {{ $testament->text }}
                     </lavel>
                     <br>
@@ -41,7 +41,7 @@
                 <h2>タグ</h2>
                 @foreach ($tags as $tag)
                     <lavel>
-                        <input type="checkbox" value={{ $tag->id }} name="tags_array[]">
+                        <input type="checkbox" value={{ $tag->id }} name="tags_array[]" {{ in_array($tag->id, old('tags_array', [])) ? 'checked' : '' }}>
                             {{ $tag->tag }}
                     </lavel>
                 @endforeach
@@ -51,5 +51,7 @@
         <div class="footer">
             <a href="{{ route('notes.index') }}">戻る</a>
         </div>
+        <!-- デバックステップ: oldヘルパーの動作確認 -->
+        <pre><code>{{ var_dump(session()->get('_old_input')) }}</code></pre>
     </body>
 </x-app-layout>

--- a/resources/views/notes/create.blade.php
+++ b/resources/views/notes/create.blade.php
@@ -28,11 +28,13 @@
             </div>
             <div class="title">
                 <h2>タイトル</h2>
-                <input type="text" name="note[title]" placeholder="タイトル">
+                <input type="text" name="note[title]" placeholder="タイトル" value="{{ old('note.title')}}">
+                <p class="title__error" style="color:red">{{ $errors->first('note.title') }}</p>
             </div>
             <div class="text">
                 <h2>本文</h2>
-                <textarea name="note[text]" placeholder="ここにノートを入力"></textarea>
+                <textarea name="note[text]" placeholder="ここにノートを入力">{{ old('note.text')}}</textarea>
+                <p class="text__error" style="color:red">{{ $errors->first('note.text') }}</p>
             </div>
             
             <div class="tag">

--- a/resources/views/notes/edit.blade.php
+++ b/resources/views/notes/edit.blade.php
@@ -5,8 +5,9 @@
     
     <body>
         <h1>Note Edit</h1>
-        <form action="/notes" method="POST">
+        <form action="/notes/{{ $note->id }}" method="POST">
             @csrf
+            @method('PUT')
             <div class="testament">
                 <label>
                     <input type="radio" value="1" name="note[public]" {{ $public_value == true ? 'checked' : '' }}>
@@ -52,7 +53,7 @@
             <a href="{{ route('notes.index') }}">戻る</a>
         </div>
         <!-- デバックステップ -->
-        <p>{{ $note->testaments }}</p>
+        <p>{{ $note->testaments->pluck('id') }}</p>
         <pre><code>{{ var_dump($note) }}</code></pre>
     </body>
 </x-app-layout>

--- a/resources/views/notes/edit.blade.php
+++ b/resources/views/notes/edit.blade.php
@@ -9,18 +9,18 @@
             @csrf
             <div class="testament">
                 <label>
-                    <input type="radio" value="1" name="note[public]" {{ $value == true ? 'checked' : '' }}>
+                    <input type="radio" value="1" name="note[public]" {{ $public_value == true ? 'checked' : '' }}>
                     公開ノート
                 </label>
                 <label>
-                    <input type="radio" value="0" name="note[public]" {{ $value == false ? 'checked' : '' }}>
+                    <input type="radio" value="0" name="note[public]" {{ $public_value == false ? 'checked' : '' }}>
                     非公開ノート
                 </label>
                 <br>
                 <h2>聖句</h2>
                 @foreach ($testaments as $testament)
                     <lavel>
-                        <input type="checkbox" value={{ $testament->id }} name="testaments_array[]">
+                        <input type="checkbox" value={{ $testament->id }} name="testaments_array[]" {{ $testament_id->contains($testament->id) ? 'checked' : '' }}>
                             {{ $testament->text }}
                     </lavel>
                     <br>
@@ -28,18 +28,20 @@
             </div>
             <div class="title">
                 <h2>タイトル</h2>
-                <input type="text" name="note[title]" placeholder="タイトル">
+                <input type="text" name="note[title]" placeholder="タイトル" value="{{ $note->title }}">
+                <p class="title__error" style="color:red">{{ $errors->first('note.title') }}</p>
             </div>
             <div class="text">
                 <h2>本文</h2>
-                <textarea name="note[text]" placeholder="ここにノートを入力"></textarea>
+                <textarea name="note[text]" placeholder="ここにノートを入力">{{ $note->text }}</textarea>
+                <p class="text__error" style="color:red">{{ $errors->first('note.text') }}</p>
             </div>
             
             <div class="tag">
                 <h2>タグ</h2>
                 @foreach ($tags as $tag)
                     <lavel>
-                        <input type="checkbox" value={{ $tag->id }} name="tags_array[]">
+                        <input type="checkbox" value={{ $tag->id }} name="tags_array[]" {{ $tag_id->contains($tag->id) ? 'checked' : '' }}>
                             {{ $tag->tag }}
                     </lavel>
                 @endforeach
@@ -49,5 +51,8 @@
         <div class="footer">
             <a href="{{ route('notes.index') }}">戻る</a>
         </div>
+        <!-- デバックステップ -->
+        <p>{{ $note->testaments }}</p>
+        <pre><code>{{ var_dump($note) }}</code></pre>
     </body>
 </x-app-layout>

--- a/resources/views/notes/edit.blade.php
+++ b/resources/views/notes/edit.blade.php
@@ -1,10 +1,10 @@
 <x-app-layout>
     <x-slot name="header">
-        　Note Create
+        　Note Edit
     </x-slot>
     
     <body>
-        <h1>Note Create</h1>
+        <h1>Note Edit</h1>
         <form action="/notes" method="POST">
             @csrf
             <div class="testament">
@@ -20,7 +20,7 @@
                 <h2>聖句</h2>
                 @foreach ($testaments as $testament)
                     <lavel>
-                        <input type="checkbox" value={{ $testament->id }} name="testaments_array[]" {{ in_array($testament->id, old('testaments_array', [])) ? 'checked' : '' }}>
+                        <input type="checkbox" value={{ $testament->id }} name="testaments_array[]">
                             {{ $testament->text }}
                     </lavel>
                     <br>
@@ -28,20 +28,18 @@
             </div>
             <div class="title">
                 <h2>タイトル</h2>
-                <input type="text" name="note[title]" placeholder="タイトル" value="{{ old('note.title')}}">
-                <p class="title__error" style="color:red">{{ $errors->first('note.title') }}</p>
+                <input type="text" name="note[title]" placeholder="タイトル">
             </div>
             <div class="text">
                 <h2>本文</h2>
-                <textarea name="note[text]" placeholder="ここにノートを入力">{{ old('note.text')}}</textarea>
-                <p class="text__error" style="color:red">{{ $errors->first('note.text') }}</p>
+                <textarea name="note[text]" placeholder="ここにノートを入力"></textarea>
             </div>
             
             <div class="tag">
                 <h2>タグ</h2>
                 @foreach ($tags as $tag)
                     <lavel>
-                        <input type="checkbox" value={{ $tag->id }} name="tags_array[]" {{ in_array($tag->id, old('tags_array', [])) ? 'checked' : '' }}>
+                        <input type="checkbox" value={{ $tag->id }} name="tags_array[]">
                             {{ $tag->tag }}
                     </lavel>
                 @endforeach
@@ -51,7 +49,5 @@
         <div class="footer">
             <a href="{{ route('notes.index') }}">戻る</a>
         </div>
-        <!-- デバックステップ: oldヘルパーの動作確認 -->
-        <pre><code>{{ var_dump(session()->get('_old_input')) }}</code></pre>
     </body>
 </x-app-layout>

--- a/resources/views/notes/index.blade.php
+++ b/resources/views/notes/index.blade.php
@@ -5,16 +5,21 @@
     
     <body>
         <h1>Note</h1>
-        <div class="testaments">
+        <div class="notes">
             <a href="{{ route('notes.create') }}">ノートを書く</a>
             @foreach($notes as $note)
-                <div class="notes">
-                    <h2>{{ $note->title }}</h2>
+                @if ($note->public === 1)
+                    <h1>公開</h1>
+                @else
+                    <h1>非公開</h1>
+                @endif
+                <p>{{ $note->created_at }}</p>
+                <a href="/notes/{{ $note->id }}">{{ $note->title }}<a>
+                <div class="testaments">
                     @foreach ($note->testaments as $testament)
                         <h3>{{ $testament->text }}</h3>
                         <p>{{ $testament->volume->title }} {{ $testament->chapter }}:{{ $testament->section }}</p>
                     @endforeach
-                    <p>{{ $note->text }}</p>
                 </div>
             @endforeach
         </div>

--- a/resources/views/notes/index.blade.php
+++ b/resources/views/notes/index.blade.php
@@ -1,10 +1,10 @@
 <x-app-layout>
     <x-slot name="header">
-        　Note
+        　Notes
     </x-slot>
     
     <body>
-        <h1>Note</h1>
+        <h1>Notes</h1>
         <div class="notes">
             <a href="{{ route('notes.create') }}">ノートを書く</a>
             @foreach($notes as $note)

--- a/resources/views/notes/index.blade.php
+++ b/resources/views/notes/index.blade.php
@@ -23,5 +23,6 @@
                 </div>
             @endforeach
         </div>
+        <pre><code>{{ var_dump($notes) }}</code></pre>
     </body>
 </x-app-layout>

--- a/resources/views/notes/show.blade.php
+++ b/resources/views/notes/show.blade.php
@@ -24,10 +24,14 @@
                         <p>{{ $tag->tag }}</p>
                     @endforeach
                 </div>
+                <div class="edit">
+                    <a href="/notes/{{ $note->id }}/edit">編集する</a>
+                </div>
                 <div class="footer">
                     <a href="{{ route('notes.index') }}">戻る</a>
                 </div>
             </div>
         </div>
+        <pre><code>{{ var_dump($note) }}</code></pre>
     </body>
 </x-app-layout>

--- a/resources/views/notes/show.blade.php
+++ b/resources/views/notes/show.blade.php
@@ -1,10 +1,10 @@
 <x-app-layout>
     <x-slot name="header">
-        　Note
+        　Note Show
     </x-slot>
     
     <body>
-        <h1>Note</h1>
+        <h1>Note Show</h1>
         <div class="notes">
             @if ($note->public === 1)
                 <h1>公開</h1>

--- a/resources/views/notes/show.blade.php
+++ b/resources/views/notes/show.blade.php
@@ -1,0 +1,33 @@
+<x-app-layout>
+    <x-slot name="header">
+        　Note
+    </x-slot>
+    
+    <body>
+        <h1>Note</h1>
+        <div class="notes">
+            @if ($note->public === 1)
+                <h1>公開</h1>
+            @else
+                <h1>非公開</h1>
+            @endif
+            <p>{{ $note->created_at }}</p>
+            <h2>{{ $note->title }}</h2>
+                <div class="testaments">
+                    @foreach ($note->testaments as $testament)
+                        <h3>{{ $testament->text }}</h3>
+                        <p>{{ $testament->volume->title }} {{ $testament->chapter }}:{{ $testament->section }}</p>
+                    @endforeach
+                </div>
+                <div class="tags">
+                    @foreach ($note->tags as $tag)
+                        <p>{{ $tag->tag }}</p>
+                    @endforeach
+                </div>
+                <div class="footer">
+                    <a href="{{ route('notes.index') }}">戻る</a>
+                </div>
+            </div>
+        </div>
+    </body>
+</x-app-layout>

--- a/resources/views/notes/show.blade.php
+++ b/resources/views/notes/show.blade.php
@@ -5,7 +5,7 @@
     
     <body>
         <h1>Note Show</h1>
-        <div class="notes">
+        <div class="note">
             @if ($note->public === 1)
                 <h1>公開</h1>
             @else

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,6 +44,10 @@ Route::get('/notes', [NoteController::class, 'index'])
 Route::get('/notes/create', [NoteController::class, 'create'])
     ->name('notes.create');
 
+// ノート詳細画面
+Route::get('/notes/{note}', [NoteController::class, 'show'])
+    ->name('notes.show');
+
 // ノート登録処理
 Route::post('/notes', [NoteController::class, 'store'])
     ->name('notes.store');

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,3 +51,9 @@ Route::get('/notes/{note}', [NoteController::class, 'show'])
 // ノート登録処理
 Route::post('/notes', [NoteController::class, 'store'])
     ->name('notes.store');
+    
+// ノート編集処理
+Route::get('/notes/{note}/edit', [NoteController::class, 'edit'])
+    ->name('notes.edit');
+Route::put('/notes/{note}', [NoteController::class, 'update'])
+    ->name('notes.update');


### PR DESCRIPTION
## 概要
以下の機能を追加した。
notesテーブルの不要なカラムの削除
ノート作成ページフォームタグの値を保存する処理
ノート詳細画面及びノート編集ページ
ノート編集ページのフォームタグの値の差分を更新する処理

## 変更点
保存処理でエラーが出たので、不要なカラムを削除した。 #13

NoteContrllerの変更点:
viewファイルから送信されたフォームを処理するstoreメソッドを追加。
-NoteRequestを新たに作成してバリデーションルールをリクエストデータに適用した。
-attachメソッドを使って、testamentsとtagsのidを複数挿入できるようにした

ノート一覧画面から特定のidを持つノートだけ閲覧するためにshowメソッドを追加

特定idのノートを編集するためeditメソッドを追加
-noteインスタンスに紐づけられたtestamentsとtagsのidを抽出するためpluckメソッドを使用

viewファイルから送信されたフォームを処理するupdateメソッドを追加。
-syncメソッドで紐づけられたidを上書きする

Viewファイルの追加・修正

showファイルを作成

createファイルを修正
-oldヘルパーを使用して、バリデーションエラーになった場合に、フォームの値を保持できるようにした
-バリデーションエラーの内容を赤字で表示するようにした
editファイルを作成
-containsメソッドで、testamentsとtagsのidとすでに紐づけられたidを比較できる

## 関連Issue
#13

## 動作確認
php artisan serveで保存処理が正常に完了して、保存した内容を一覧表示できていることを確認

## その他
ノート削除機能をまだ実装できていない。
参考にした他の実装
(https://codelikes.com/laravel-old/#toc1)
(https://qiita.com/hinako_n/items/18957b35124c75fc712d)