### PR TITLE
feat: #16 Add delete function

### DIFF
--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -103,4 +103,13 @@ class NoteController extends Controller
           
           return redirect('/notes/' . $note->id);
       }
+      
+      /**
+       * ノート削除処理
+       */
+       public function delete(Note $note)
+       {
+           $note->delete();
+           return redirect(route('notes.index'));
+       }
 }

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -4,18 +4,18 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes; //論理削除
 
 class Note extends Model
 {
     use HasFactory;
+    use SoftDeletes;
     
     protected $fillable = [
         'title',
         'text',
         'user_id',
         'public',
-        'created_at',
-        'updated_at',
         ];
     
     /**

--- a/resources/views/notes/index.blade.php
+++ b/resources/views/notes/index.blade.php
@@ -21,8 +21,24 @@
                         <p>{{ $testament->volume->title }} {{ $testament->chapter }}:{{ $testament->section }}</p>
                     @endforeach
                 </div>
+                <p>{{ $note->text }}</p>
+                <form action="/notes/{{ $note->id }}" id="form_{{ $note->id }}" method="post">
+                    @csrf
+                    @method('DELETE')
+                    <button type="button" onclick="deleteNote({{ $note->id }})">このノートを削除する</button>
+                </form>
             @endforeach
+            <!-- デバックステップ -->
+            <pre><code>{{ var_dump($notes) }}</code></pre>
         </div>
-        <pre><code>{{ var_dump($notes) }}</code></pre>
+        <script>
+            function deleteNote(id) {
+                'use strict'
+                
+                if (confirm('削除すると復元できません。本当に削除しますか？')) {
+                    document.getElementById(`form_${id}`).submit();
+                }
+            }
+        </script>
     </body>
 </x-app-layout>

--- a/resources/views/notes/show.blade.php
+++ b/resources/views/notes/show.blade.php
@@ -19,6 +19,7 @@
                         <p>{{ $testament->volume->title }} {{ $testament->chapter }}:{{ $testament->section }}</p>
                     @endforeach
                 </div>
+                <p>{{ $note->text }}</p>
                 <div class="tags">
                     @foreach ($note->tags as $tag)
                         <p>{{ $tag->tag }}</p>
@@ -31,7 +32,8 @@
                     <a href="{{ route('notes.index') }}">戻る</a>
                 </div>
             </div>
+            <!-- デバックステップ -->
+            <pre><code>{{ var_dump($note) }}</code></pre>
         </div>
-        <pre><code>{{ var_dump($note) }}</code></pre>
     </body>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,3 +57,7 @@ Route::get('/notes/{note}/edit', [NoteController::class, 'edit'])
     ->name('notes.edit');
 Route::put('/notes/{note}', [NoteController::class, 'update'])
     ->name('notes.update');
+    
+// ノート削除処理
+Route::delete('/notes/{note}', [NoteController::class, 'delete'])
+    ->name('notes.delete');


### PR DESCRIPTION
## 概要
指定のノートを論理削除する機能を追加した。

## 変更点
viewファイルにDELETEリクエストを送信するフォームタグを追加
-methodディレクティブでリクエストメソッドを設定
-onclick属性で、scriptタグに書かれたイベントを設定
-scriptタグにダイアログを表示するJavaScriptを実装。trueのとき指定のform_idが送信される

コントローラにdeleteメソッドを追加。指定のidを持つnoteインスタンスに対してdelete()メソッドを実行する

モデルにSoftDeletesを設定。delete関数の実行時に論理削除する。

## 動作確認
すでにあるノートを削除できることを確認