### PR TITLE
Feat #25 breadcrumb navigation

### DIFF
--- a/app/Http/Controllers/TestamentController.php
+++ b/app/Http/Controllers/TestamentController.php
@@ -52,6 +52,7 @@ class TestamentController extends Controller
         
         return view('testaments.show')->with([
             'volume' => $volume,
+            'chapter' => $chapter,
             'testaments' => $contents,
             'chapter_set' => $chapter_set,
             'latest_chapter' => $latest_chapter, 

--- a/app/Http/Controllers/TestamentController.php
+++ b/app/Http/Controllers/TestamentController.php
@@ -4,36 +4,54 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Testament;
+use App\Models\Volume;
 
 class TestamentController extends Controller
 {
-    
     /**
      * 聖書一覧画面
+     */
+     public function index(Volume $volume)
+     {
+         return view('testaments.index')->with(['volumes' => $volume->get()]);
+     }
+     
+    /**
+     * volumeの章一覧を表示
+     */
+    public function displayVolumeWithContents($volume ,Testament $testament)
+    {
+        $chapters = $testament->where('volume_id', $volume)->groupBy('chapter')->pluck('chapter');
+        
+        return view('testaments.volume')->with(['volume' => $volume, 'chapters' => $chapters]);
+    }
+     
+    /**
+     * 聖書詳細画面
      * 
      * @param object Testament
      * @return Response testament.show view
      */
-    
-    public function displayChapterWithContents(Testament $testament, $volume_id = 1, $chapter = 1)
+    public function displayChapterWithContents($volume, $chapter, Testament $testament)
     {
         $contents = $testament->where([
-            ['volume_id', $volume_id],
+            ['volume_id', $volume],
             ['chapter', $chapter],
             ])->get();
         
         $chapter_set = $contents->first();
         
         // 最小のchapterを取得
-        $earliest_chapter = $testament->getChapter($volume_id, false);
+        $earliest_chapter = $testament->getChapter($volume, false);
         
         // 最大のchapterを取得
-        $latest_chapter = $testament->getChapter($volume_id);
+        $latest_chapter = $testament->getChapter($volume);
         
-        //インスタンスのvolume_id未満のvolume_idの中で最新のchapterを取得                           
-        $previous_volume_latest_chapter = $testament->getPreviousVolumeLatestChapter($volume_id);
+        //インスタンスのvolume_id未満のvolume_idの中で最新のchapterを取得                         
+        $previous_volume_latest_chapter = $testament->getPreviousVolumeLatestChapter($volume);
         
-        return view('testaments.index')->with([
+        return view('testaments.show')->with([
+            'volume' => $volume,
             'testaments' => $contents,
             'chapter_set' => $chapter_set,
             'latest_chapter' => $latest_chapter, 

--- a/app/Models/Testament.php
+++ b/app/Models/Testament.php
@@ -72,7 +72,7 @@ class Testament extends Model
      */
     public function getPreviousVolumeLatestChapter($volume_id)
     {
-        $chapter = $this->where('volume_id', '<', $volume_id)
+        $chapter = $this->where('volume_id', '<=', $volume_id)
             ->select('volume_id', \DB::raw('MAX(chapter) as chapter_id'))
             ->groupBy('volume_id')
             ->orderBy('volume_id', 'desc')

--- a/resources/views/testaments/show.blade.php
+++ b/resources/views/testaments/show.blade.php
@@ -6,7 +6,7 @@
     <body>
         <div class="testaments">
             <div class="py-12">
-                <a href="/testaments">Home</a> > <a href="/testaments/volume{{ $volume }}">Volume {{ $volume }}</a> > <span>Chapter {{ $chapter_set->chapter }}</span>
+                <a href="/testaments">Home</a> > <a href="/testaments/volume{{ $volume }}">Volume {{ $volume }}</a> > <span>Chapter {{ $chapter }}</span>
                 <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                         <div class="p-6 text-gray-900">
@@ -23,7 +23,7 @@
         <!--現時点のchapterの値に応じて、前後のページに移動するメカニズム -->
         <div class="pagination">
             <br>
-            @if ($volume === 1 and $testament->chapter === 1)
+            @if ($volume == 1 and $chapter == 1)
                 <p></p>
             @elseif ($earliest_chapter->chapter_id === $testament->chapter)
                 <a href="/testaments/volume{{ $volume - 1 }}/chapter{{ $previous_volume_latest_chapter->chapter_id }}">←</a>
@@ -40,6 +40,7 @@
             @endif
             <br>
         </div>
+            {{ $volume }} {{ $chapter}}
             {{ $latest_chapter }}
             {{ $earliest_chapter }}
             {{ $previous_volume_latest_chapter }}

--- a/resources/views/testaments/show.blade.php
+++ b/resources/views/testaments/show.blade.php
@@ -1,0 +1,48 @@
+<x-app-layout>
+    <x-slot name="header">
+        　Testament Show
+    </x-slot>
+    
+    <body>
+        <div class="testaments">
+            <div class="py-12">
+                <a href="/testaments">Home</a> > <a href="/testaments/volume{{ $volume }}">Volume {{ $volume }}</a> > <span>Chapter {{ $chapter_set->chapter }}</span>
+                <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                        <div class="p-6 text-gray-900">
+                            <h2>{{ $chapter_set->volume->title }}: 第{{ $chapter_set->chapter }}章</h2>
+                            @foreach ($testaments as $testament)
+                                <input type="checkbox" value={{ $testament->id }} name="testaments_array[]">
+                                <small>{{ $testament->section }}</small> {{ $testament->text }}
+                            @endforeach
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!--現時点のchapterの値に応じて、前後のページに移動するメカニズム -->
+        <div class="pagination">
+            <br>
+            @if ($volume === 1 and $testament->chapter === 1)
+                <p></p>
+            @elseif ($earliest_chapter->chapter_id === $testament->chapter)
+                <a href="/testaments/volume{{ $volume - 1 }}/chapter{{ $previous_volume_latest_chapter->chapter_id }}">←</a>
+            @else
+                <a href="/testaments/volume{{ $volume }}/chapter{{ $testament->chapter - 1 }}">←</a>
+            @endif
+            
+            @if ($volume === 66 and $testament->chapter === 21)
+                <p></p>
+            @elseif ($latest_chapter->chapter_id === $testament->chapter)
+                <a href="/testaments/volume{{ $volume + 1 }}/chapter1">→</a>
+            @else
+                <a href="/testaments/volume{{ $volume }}/chapter{{ $testament->chapter + 1 }}">→</a>
+            @endif
+            <br>
+        </div>
+            {{ $latest_chapter }}
+            {{ $earliest_chapter }}
+            {{ $previous_volume_latest_chapter }}
+            {{ dump($testaments) }}
+    </body>
+</x-app-layout>

--- a/resources/views/testaments/volume.blade.php
+++ b/resources/views/testaments/volume.blade.php
@@ -6,15 +6,14 @@
     <body>
         <div class="testaments">
             <div class="py-12">
-                <p>Home</p>
+                <a href="/testaments">Home</a> > <span>Volume {{ $volume }}</span>
                 <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                         <div class="p-6 text-gray-900">
-                            @foreach ($volumes as $volume)
-                                <a href="/testaments/volume{{ $volume->id }}">{{ $volume->title }}</a>
-                                <br>
+                            @foreach ($chapters as $chapter)
+                                <a href="/testaments/volume{{ $volume }}/chapter{{ $chapter }}">第{{ $chapter }}章</a>
                             @endforeach
-                            {{ dump($volumes)}}
+                            {{ dump($chapters)}}
                         </div>
                     </div>
                 </div>

--- a/resources/views/testaments/volume.blade.php
+++ b/resources/views/testaments/volume.blade.php
@@ -11,7 +11,7 @@
                     <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                         <div class="p-6 text-gray-900">
                             @foreach ($chapters as $chapter)
-                                <a href="/testaments/volume{{ $volume }}/chapter{{ $chapter }}">第{{ $chapter }}章</a>
+                                <a href="/testaments/volume{{ $volume }}/chapter{{ $chapter }}">Chapter {{ $chapter }}</a>
                             @endforeach
                             {{ dump($chapters)}}
                         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,8 +35,6 @@ require __DIR__.'/auth.php';
 
 Route::get('/testaments', [TestamentController::class, 'index'])->name('testaments.index');
 Route::get('/testaments/volume{volume}', [TestamentController::class, 'displayVolumeWithContents']);
-
-// 聖書詳細画面
 Route::get('/testaments/volume{volume}/chapter{chapter}', [TestamentController::class, 'displayChapterWithContents'])
     ->name('testaments.show');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,9 +33,12 @@ Route::middleware('auth')->group(function () {
 
 require __DIR__.'/auth.php';
 
-// 聖書一覧画面
-Route::get('/testaments/{volume_id?}/{chapter?}', [TestamentController::class, 'displayChapterWithContents'])
-    ->name('testaments.index');
+Route::get('/testaments', [TestamentController::class, 'index'])->name('testaments.index');
+Route::get('/testaments/volume{volume}', [TestamentController::class, 'displayVolumeWithContents']);
+
+// 聖書詳細画面
+Route::get('/testaments/volume{volume}/chapter{chapter}', [TestamentController::class, 'displayChapterWithContents'])
+    ->name('testaments.show');
 
 // ノート一覧画面
 Route::get('/notes', [NoteController::class, 'index'])


### PR DESCRIPTION
## 概要
- views/testamentsのディレクトリ構成を変更して、それぞれのbladeファイルでvolumeのリスト、特定のvolumeのchapterリスト、chapterに属するsectionのリストを表示するようにした。
- パンくずリストを作成した。

## 変更点
- ファイル名変更: index.blade.php → show.blade.php
- testamentsにファイルを2つ追加
> index.blade.php,volume.blade.php
- それぞれのページに対応するMVCモデルを実装。
- ページ遷移のバグを修正した