### PR TITLE
Refactor #27 summarize quotations

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -19,15 +19,11 @@ class CommentController extends Controller
         
         $comment_testament = $testament->get();
         
-        return view('notes.comments.index')->with(['note_id' => $note, 'comments' => $comments, 'comment_testaments' => $comment_testament]);
-    }
-    
-    /**
-     * コメント詳細画面
-     */
-    public function show($comment)
-    {
-        //
+        return view('notes.comments.index')->with([
+            'note_id' => $note,
+            'comments' => $comments,
+            'comment_testaments' => $comment_testament,
+            ]);
     }
      
     /**

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -29,29 +29,49 @@ class NoteController extends Controller
      */
      public function show(Note $note)
      {
-         $testaments_v = $note->testaments; //便宜上名前を変更
+         $testaments_query_builder = $note->testaments;
          
-         $testaments_by_volume = $testaments_v->groupBy('volume_id');
-         
-         $testaments = $note->testaments()->with('volume')->get(); // 関連付けられた testaments を取得
-         
+         // volume_id をキーとし、その下に chapter をキーとした testaments の多重連想配列
+         $testaments_by_volume_and_chapter = $testaments_query_builder->groupBy('volume_id')->map(function ($testaments) {
+             return $testaments->groupBy('chapter');
+         });
+        
+         /**
+          * 各volume_id、chapterごとに、最初のsectionと最後のsectionを記録する処理
+          */
+         // リレーションシップを含むすべてのtestamentsを取得
+         $loaded_testaments_with_volume = $note->testaments()->with('volume')->get();
+        
+         // chapterごとに最初のsectionと最後のsectionを格納する連想配列
          $section_info_by_volume = [];
          
-         foreach ($testaments as $testament) {
+         foreach ($loaded_testaments_with_volume as $testament) {
              $volume_id = $testament->volume->id;
+             $chapter = $testament->chapter;
+             $section = $testament->section;
              
-             if (!isset($section_info_by_volume[$volume_id])) {
-                 $section_info_by_volume[$volume_id] = [
-                     'first_section' => $testament->section,
-                     'last_section' => $testament->section,
+             // $section_info_by_volumeに$volume_id、$chapterに関連づけられたエントリが存在するか確認
+             if (!isset($section_info_by_volume[$volume_id][$chapter])) {
+                 // 存在しないなら新しいvolume_id、$chapter用のエントリを作成
+                 $section_info_by_volume[$volume_id][$chapter] = [
+                     'first_section' => $section,
+                     'last_section' => $section,
                      ];
              } else {
-                 $section_info_by_volume[$volume_id]['last_section'] = $testament->section;
+                 // 最小のsectionを更新
+                 if ($section < $section_info_by_volume[$volume_id][$chapter]['first_section']) {
+                     $section_info_by_volume[$volume_id][$chapter]['first_section'] = $section;
+                 }
+                 
+                 // 最大のsectionを更新
+                 if ($section > $section_info_by_volume[$volume_id][$chapter]['last_section']) {
+                     $section_info_by_volume[$volume_id][$chapter]['last_section'] = $section;
+                 }
              }
          }
-         
+
          return view('notes.show')->with([
-             'testaments_by_volume' => $testaments_by_volume,
+             'testaments_by_volume_and_chapter' => $testaments_by_volume_and_chapter,
              'section_info_by_volume' => $section_info_by_volume,
              'note' => $note]);
      }

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -16,6 +16,7 @@ class NoteController extends Controller
      */
     public function index(Note $note)
     {
+        $notes = $note->get();
         return view('notes.index')->with(['notes' => $note->get()]);
     }
     
@@ -28,7 +29,31 @@ class NoteController extends Controller
      */
      public function show(Note $note)
      {
-         return view('notes.show')->with(['note' => $note]);
+         $testaments_v = $note->testaments; //便宜上名前を変更
+         
+         $testaments_by_volume = $testaments_v->groupBy('volume_id');
+         
+         $testaments = $note->testaments()->with('volume')->get(); // 関連付けられた testaments を取得
+         
+         $section_info_by_volume = [];
+         
+         foreach ($testaments as $testament) {
+             $volume_id = $testament->volume->id;
+             
+             if (!isset($section_info_by_volume[$volume_id])) {
+                 $section_info_by_volume[$volume_id] = [
+                     'first_section' => $testament->section,
+                     'last_section' => $testament->section,
+                     ];
+             } else {
+                 $section_info_by_volume[$volume_id]['last_section'] = $testament->section;
+             }
+         }
+         
+         return view('notes.show')->with([
+             'testaments_by_volume' => $testaments_by_volume,
+             'section_info_by_volume' => $section_info_by_volume,
+             'note' => $note]);
      }
     
     /**

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -49,4 +49,9 @@ class Note extends Model
       {
           return $this->belongsTo(User::class);
       }
+      
+      public function recordSectionInfoByVolumeAndChapter()
+      {
+          //section番号を取得するメソッドを書く
+      }
 }

--- a/resources/views/notes/index.blade.php
+++ b/resources/views/notes/index.blade.php
@@ -17,12 +17,6 @@
                             @endif
                             <p>{{ $note->created_at }}</p>
                             <a href="/notes/{{ $note->id }}">{{ $note->title }}<a>
-                            <div class="testaments">
-                                @foreach ($note->testaments as $testament)
-                                    <h3>{{ $testament->text }}</h3>
-                                    <p>{{ $testament->volume->title }} {{ $testament->chapter }}:{{ $testament->section }}</p>
-                                @endforeach
-                            </div>
                             <div class="note_text">
                                 <p>{{ $note->text }}</p>
                             </div>

--- a/resources/views/notes/show.blade.php
+++ b/resources/views/notes/show.blade.php
@@ -17,17 +17,20 @@
                     <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                         <div class="p-6 text-gray-900">
                             @if ($note->public === 1)
-                                <h1>公開</h1>
+                                <h1>公開ノート</h1>
                             @else
-                                <h1>非公開</h1>
+                                <h1>非公開ノート</h1>
                             @endif
                             <div class="testaments">
                                 <br>
-                                @foreach ($testaments_by_volume as $volume_id => $testaments)
-                                    @foreach ($testaments as $testament)
-                                        <p>{{ $testament->text }}</p>
+                                @foreach ($testaments_by_volume_and_chapter as $volume_id => $chapters)
+                                    @foreach ($chapters as $chapter => $testaments)
+                                        @foreach ($testaments as $testament)
+                                            <p>{{ $testament->text }}</p>
+                                        @endforeach
+                                        <p>{{ $testament->volume->title }} {{ $chapter }}:{{ $section_info_by_volume[$volume_id][$chapter]['first_section'] }}-{{ $section_info_by_volume[$volume_id][$chapter]['last_section'] }}</p>
+                                        <br>
                                     @endforeach
-                                    <p>{{ $testament->volume->title }}:{{ $section_info_by_volume[$volume_id]['first_section'] }}-{{ $section_info_by_volume[$volume_id]['last_section'] }}</p>
                                 @endforeach
                                 <br>
                             </div>
@@ -59,7 +62,7 @@
             </div>
         </div>
         <!-- デバックステップ -->
-        {{ dump($testament->volume->title) }}
+        {{ dump($testament->chapter) }}
         {{ dump($note) }}
     </body>
 </x-app-layout>

--- a/resources/views/notes/show.blade.php
+++ b/resources/views/notes/show.blade.php
@@ -21,14 +21,18 @@
                             @else
                                 <h1>非公開</h1>
                             @endif
+                            <div class="testaments">
+                                <br>
+                                @foreach ($testaments_by_volume as $volume_id => $testaments)
+                                    @foreach ($testaments as $testament)
+                                        <p>{{ $testament->text }}</p>
+                                    @endforeach
+                                    <p>{{ $testament->volume->title }}:{{ $section_info_by_volume[$volume_id]['first_section'] }}-{{ $section_info_by_volume[$volume_id]['last_section'] }}</p>
+                                @endforeach
+                                <br>
+                            </div>
                             <p>{{ $note->created_at }}</p>
                             <h2>{{ $note->title }}</h2>
-                            <div class="testaments">
-                                @foreach ($note->testaments as $testament)
-                                    <h3>{{ $testament->text }}</h3>
-                                    <p>{{ $testament->volume->title }} {{ $testament->chapter }}:{{ $testament->section }}</p>
-                                @endforeach
-                            </div>
                             <p>{{ $note->text }}</p>
                             <div class="tags">
                                 @foreach ($note->tags as $tag)
@@ -55,6 +59,7 @@
             </div>
         </div>
         <!-- デバックステップ -->
+        {{ dump($testament->volume->title) }}
         {{ dump($note) }}
     </body>
 </x-app-layout>


### PR DESCRIPTION
## 概要

- ノートに登録してある引用句を読みやすくするために、volumeとchapterごとに引用文献情報を表示できるようにした。

## 変更点
NoteControllerのshowメソッドに処理を追加

1. `groupBy()`メソッドを利用して、`$note`の各 volume_id に関連する chapter ごとにグループ分けをする処理を追加
    - このCollectionインスタンスを使って、viewファイルで引用句をchapter毎に表示する
2. 引用句のsection情報を取得できる処理
    - `$note`インスタンスの持つtestamentsをグループ分けして、各volume_id、chapterごとに、最初のsectionと最後のsectionを記録する処理 
    - viewファイルで各引用句の文献情報を表示する時に使用される
3. viewファイルで引用句と文献情報を表示できるようにした