### PR TITLE
feat: #22 Direct registration

### DIFF
--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -80,14 +80,18 @@ class NoteController extends Controller
      * ノート作成画面
      * $public_valueは、ラジオボタンのchecked属性を動的に制御するために用意
      */
-    public function create(Tag $tag, Testament $testament)
+    public function create(Request $request, Tag $tag)
     {
+        $selected_testaments = $request->input('testaments_array', []);
+       
+        $testaments = Testament::whereIn('id', $selected_testaments)->get();
+        
         $public_value = 'true';
         
         return view('notes.create')->with([
             'public_value' => $public_value,
             'tags' => $tag->get(),
-            'testaments' => $testament->get(),
+            'testaments' => $testaments,
             ]);
     }
     

--- a/resources/views/notes/comments/index.blade.php
+++ b/resources/views/notes/comments/index.blade.php
@@ -9,7 +9,7 @@
         </div>
         <div class="comments">
             @foreach ($comments as $comment)
-                <br>
+                <br>r
                 <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                         <div class="p-6 text-gray-900">

--- a/resources/views/notes/create.blade.php
+++ b/resources/views/notes/create.blade.php
@@ -25,12 +25,10 @@
                                 <br>
                                 <h2>聖句</h2>
                                 @foreach ($testaments as $testament)
-                                    <lavel>
-                                        <input type="checkbox" value={{ $testament->id }} name="testaments_array[]" {{ in_array($testament->id, old('testaments_array', [])) ? 'checked' : '' }}>
-                                            {{ $testament->text }}
-                                    </lavel>
-                                    <br>
+                                    <input type="hidden" name="testaments_array[]" value="{{ $testament->id }}">
+                                    <p>{{ $testament->text }}</p>
                                 @endforeach
+                                <br>
                             </div>
                             <div class="title">
                                 <h2>タイトル</h2>

--- a/resources/views/testaments/show.blade.php
+++ b/resources/views/testaments/show.blade.php
@@ -8,12 +8,13 @@
             <div class="py-12">
                 <a href="/testaments">Home</a> > <a href="/testaments/volume{{ $volume }}">Volume {{ $volume }}</a> > <span>Chapter {{ $chapter }}</span>
                 <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                    <a href="#" id="sendData">ノートを作成する</a>
                     <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                         <div class="p-6 text-gray-900">
                             <h2>{{ $chapter_set->volume->title }}: 第{{ $chapter_set->chapter }}章</h2>
                             @foreach ($testaments as $testament)
                                 <input type="checkbox" value={{ $testament->id }} name="testaments_array[]">
-                                <small>{{ $testament->section }}</small> {{ $testament->text }}
+                                <small>{{ $testament->section }}</small> {{ $testament->text }}<br>
                             @endforeach
                         </div>
                     </div>
@@ -46,4 +47,31 @@
             {{ $previous_volume_latest_chapter }}
             {{ dump($testaments) }}
     </body>
+    <script>
+        // aタグをクリックした際の処理
+        document.getElementById('sendData').addEventListener('click', function(e) {
+            e.preventDefault(); // デフォルトのリンク挙動を無効化
+        
+            // 選択されたチェックボックスの値を収集
+            var selectedTestaments = document.querySelectorAll('input[name="testaments_array[]"]:checked');
+            var values = [];
+            selectedTestaments.forEach(function(testament) {
+                values.push(testament.value);
+            });
+        
+            // チェックボックスが1つ以上選択されている場合
+            if (values.length > 0) {
+                // クエリパラメータを作成
+                var queryString = 'testaments_array[]=' + values.join('&testaments_array[]=');
+                
+                // GETリクエストを送信するURLを作成
+                var url = '/notes/create?' + queryString;
+        
+                // GETリクエストを実行
+                window.location.href = url;
+            } else {
+                alert('少なくとも1つのアイテムを選択してください');
+            }
+        });
+    </script>
 </x-app-layout>


### PR DESCRIPTION
## 概要
聖書を読む画面で選択した聖句を直接ノート作成画面に渡して保存できるようにした。

## 変更点
- 聖書閲覧画面
  - 「ノートを作成する」という`<a>`要素を追加。クリックするとJavaScript処理を実行する。
  - JavaScript処理を追加。`<input>`要素の中から`name`属性が `testaments_array[]` であり、`checked`されているものを選択する。選択した値で生成したクエリパラメータをノート作成画面のURLに追加して、GETリクエストを送信する。
- コントローラメソッド
  - `$request`インスタンスからクエリパラメータを取得して、その値と同じ`id`を持つtestamentsレコードを取得する。それらの値を`$testaments`としてviewファイルに渡す。
- ノート作成画面
  - `$testaments`の値は`hidden`フィールドを使ってフォームに含む
## やってないこと
- ノートに複数の箇所の聖句を保存したいが、今は特定の`volume->id`と`chapter`の値を持つ聖句しか保存できない。セッションを使って保存処理をするまで`$testament->id`の情報を保持したいが、やり方がわからなくなっている。