### PR TITLE
Feat #32 upload image

### DIFF
--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -105,11 +105,14 @@ class NoteController extends Controller
          $input_note = $request['note'];
          $input_testaments = $request->testaments_array;
          $input_tags = $request->tags_array;
-         //cloudinaryへ画像を送信し、画像のURLを$image_urlに代入
-         $image_url = Cloudinary::upload($request->file('image')->getRealPath())->getSecurePath();
+         
+         if ($request->file('image')) { //画像ファイルが送られたときだけ処理が実行される
+            //cloudinaryへ画像を送信し、画像のURLを$image_urlに代入
+            $image_url = Cloudinary::upload($request->file('image')->getRealPath())->getSecurePath();
+            $input_note += ['image_url' => $image_url];
+         }
          
          $input_note += ['user_id' => $request->user()->id]; // user():requestを送信したユーザーの情報を取得するRequestメソッド
-         $input_note += ['image_url' => $image_url];
          $note->fill($input_note)->save();
          
          // attachメソッドを使って中間テーブルにデータを保存

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -8,6 +8,7 @@ use App\Models\Tag;
 use App\Models\Testament;
 use App\Models\Comment;
 use App\Http\Requests\NoteRequest;
+use Cloudinary;
 
 class NoteController extends Controller
 {
@@ -104,8 +105,11 @@ class NoteController extends Controller
          $input_note = $request['note'];
          $input_testaments = $request->testaments_array;
          $input_tags = $request->tags_array;
+         //cloudinaryへ画像を送信し、画像のURLを$image_urlに代入
+         $image_url = Cloudinary::upload($request->file('image')->getRealPath())->getSecurePath();
          
          $input_note += ['user_id' => $request->user()->id]; // user():requestを送信したユーザーの情報を取得するRequestメソッド
+         $input_note += ['image_url' => $image_url];
          $note->fill($input_note)->save();
          
          // attachメソッドを使って中間テーブルにデータを保存

--- a/app/Http/Requests/NoteRequest.php
+++ b/app/Http/Requests/NoteRequest.php
@@ -26,6 +26,7 @@ class NoteRequest extends FormRequest
         return [
             'note.title' => 'required',
             'note.text' => 'required',
+            'image' => 'max:2097152',
         ];
     }
 }

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -16,6 +16,7 @@ class Note extends Model
         'text',
         'user_id',
         'public',
+        'image_url',
         ];
     
     /**

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.0.2",
+        "cloudinary-labs/cloudinary-laravel": "^2.0",
         "doctrine/dbal": "^3.7",
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^9.19",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0af5b27bc1bea803f2b1b080a14e5a9c",
+    "content-hash": "6026d303da582ada088ed485b372058b",
     "packages": [
         {
             "name": "brick/math",
@@ -60,6 +60,202 @@
                 }
             ],
             "time": "2023-01-15T23:15:59+00:00"
+        },
+        {
+            "name": "cloudinary-labs/cloudinary-laravel",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cloudinary-devs/cloudinary-laravel.git",
+                "reference": "f331b770b277a75dbde3c61bf1e50096b3e68104"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cloudinary-devs/cloudinary-laravel/zipball/f331b770b277a75dbde3c61bf1e50096b3e68104",
+                "reference": "f331b770b277a75dbde3c61bf1e50096b3e68104",
+                "shasum": ""
+            },
+            "require": {
+                "cloudinary/cloudinary_php": "^2.0",
+                "ext-json": "*",
+                "illuminate/support": "~6|~7|~8|^9.0|^10.0",
+                "php": "^8.0.2"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.1",
+                "orchestra/testbench": "~4|~5|~6|^7.0",
+                "phpunit/phpunit": "^8.0|^9.5.10",
+                "sempro/phpunit-pretty-print": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "CloudinaryLabs\\CloudinaryLaravel\\CloudinaryServiceProvider"
+                    ],
+                    "aliases": {
+                        "Cloudinary": "CloudinaryLabs\\CloudinaryLaravel\\Facades\\Cloudinary"
+                    }
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Support/helpers.php"
+                ],
+                "psr-4": {
+                    "CloudinaryLabs\\CloudinaryLaravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Prosper Otemuyiwa",
+                    "email": "prosperotemuyiwa@gmail.com",
+                    "homepage": "https://github.com/unicodeveloper"
+                }
+            ],
+            "description": "A Laravel Cloudinary Package",
+            "homepage": "https://github.com/cloudinary-labs/cloudinary-laravel",
+            "keywords": [
+                "File Transformations",
+                "Media management",
+                "cloudinary",
+                "cloudinary-laravel",
+                "file uploads",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/cloudinary-devs/cloudinary-laravel/issues",
+                "source": "https://github.com/cloudinary-devs/cloudinary-laravel/tree/2.0.3"
+            },
+            "time": "2023-03-01T15:07:23+00:00"
+        },
+        {
+            "name": "cloudinary/cloudinary_php",
+            "version": "2.12.0",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:cloudinary/cloudinary_php.git",
+                "reference": "57290a5e24bee1d65939713f6ef8f75d93f2d6b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cloudinary/cloudinary_php/zipball/57290a5e24bee1d65939713f6ef8f75d93f2d6b6",
+                "reference": "57290a5e24bee1d65939713f6ef8f75d93f2d6b6",
+                "shasum": ""
+            },
+            "require": {
+                "cloudinary/transformation-builder-sdk": "^1",
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.5.8|^7.4.5",
+                "guzzlehttp/promises": "^1.5.3|^2.0",
+                "guzzlehttp/psr7": "^1.9.1|^2.5",
+                "monolog/monolog": "^1|^2|^3",
+                "php": ">=5.6.0",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "consolidation/robo": "~1",
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "*",
+                "phpmd/phpmd": "*",
+                "squizlabs/php_codesniffer": "3.*",
+                "symfony/phpunit-bridge": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cloudinary",
+                    "homepage": "https://github.com/cloudinary/cloudinary_php/graphs/contributors"
+                }
+            ],
+            "description": "Cloudinary PHP SDK",
+            "homepage": "https://github.com/cloudinary/cloudinary_php",
+            "keywords": [
+                "cdn",
+                "cloud",
+                "cloudinary",
+                "image management",
+                "sdk"
+            ],
+            "support": {
+                "email": "info@cloudinary.com",
+                "issues": "https://github.com/cloudinary/cloudinary_php/issues"
+            },
+            "time": "2023-12-03T13:57:09+00:00"
+        },
+        {
+            "name": "cloudinary/transformation-builder-sdk",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:cloudinary/php-transformation-builder-sdk.git",
+                "reference": "5cb90466be7f2ff35b02977295750504f8085b46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cloudinary/php-transformation-builder-sdk/zipball/5cb90466be7f2ff35b02977295750504f8085b46",
+                "reference": "5cb90466be7f2ff35b02977295750504f8085b46",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "consolidation/robo": "~1",
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "*",
+                "phpmd/phpmd": "*",
+                "squizlabs/php_codesniffer": "3.*",
+                "symfony/phpunit-bridge": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cloudinary",
+                    "homepage": "https://github.com/cloudinary/php-transformation-builder-sdk/graphs/contributors"
+                }
+            ],
+            "description": "Cloudinary PHP Transformation Builder SDK",
+            "homepage": "https://github.com/cloudinary/php-transformation-builder-sdk",
+            "keywords": [
+                "cdn",
+                "cloud",
+                "cloudinary",
+                "image management",
+                "sdk"
+            ],
+            "support": {
+                "email": "info@cloudinary.com",
+                "issues": "https://github.com/cloudinary/php-transformation-builder-sdk/issues"
+            },
+            "time": "2023-10-04T13:11:09+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/config/app.php
+++ b/config/app.php
@@ -181,7 +181,7 @@ return [
         Illuminate\Translation\TranslationServiceProvider::class,
         Illuminate\Validation\ValidationServiceProvider::class,
         Illuminate\View\ViewServiceProvider::class,
-
+        
         /*
          * Package Service Providers...
          */
@@ -194,6 +194,9 @@ return [
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        
+        CloudinaryLabs\CloudinaryLaravel\CloudinaryServiceProvider::class,
+
 
     ],
 

--- a/config/cloudinary.php
+++ b/config/cloudinary.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Laravel Cloudinary package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cloudinary Configuration
+    |--------------------------------------------------------------------------
+    |
+    | An HTTP or HTTPS URL to notify your application (a webhook) when the process of uploads, deletes, and any API
+    | that accepts notification_url has completed.
+    |
+    |
+    */
+    'notification_url' => env('CLOUDINARY_NOTIFICATION_URL'),
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cloudinary Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Cloudinary settings. Cloudinary is a cloud hosted
+    | media management service for all file uploads, storage, delivery and transformation needs.
+    |
+    |
+    */
+    'cloud_url' => env('CLOUDINARY_URL'),
+
+    /**
+     * Upload Preset From Cloudinary Dashboard
+     *
+     */
+    'upload_preset' => env('CLOUDINARY_UPLOAD_PRESET'),
+
+];

--- a/database/migrations/2023_12_18_182101_add_image_url_to_notes_table.php
+++ b/database/migrations/2023_12_18_182101_add_image_url_to_notes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('notes', function (Blueprint $table) {
+            $table->string('image_url');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('notes', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2023_12_18_184623_change_image_url_to_nullable.php
+++ b/database/migrations/2023_12_18_184623_change_image_url_to_nullable.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('notes', function (Blueprint $table) {
+            $table->string('image_url')->nullable(true)->change(); //nullable()の引数をtrue。change()で既存のカラムを変更
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('notes', function (Blueprint $table) {
+            $table->string('image_url')->nullable(false)->change();
+        });
+    }
+};

--- a/resources/views/notes/create.blade.php
+++ b/resources/views/notes/create.blade.php
@@ -11,7 +11,7 @@
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                     <div class="p-6 text-gray-900">
-                        <form action="/notes" method="POST">
+                        <form action="/notes" method="POST" enctype="multipart/form-data">
                             @csrf
                             <div class="testament">
                                 <label>
@@ -49,6 +49,9 @@
                                             {{ $tag->tag }}
                                     </lavel>
                                 @endforeach
+                            </div>
+                            <div class="image">
+                                <input type="file" name="image">
                             </div>
                             <input type="submit" value="保存する"/>
                         </form>

--- a/resources/views/notes/create.blade.php
+++ b/resources/views/notes/create.blade.php
@@ -52,6 +52,7 @@
                             </div>
                             <div class="image">
                                 <input type="file" name="image">
+                                <p class="image__error" style="color:red">{{ $errors->first('image') }}</p>
                             </div>
                             <input type="submit" value="保存する"/>
                         </form>

--- a/resources/views/notes/show.blade.php
+++ b/resources/views/notes/show.blade.php
@@ -42,6 +42,9 @@
                                     <p>{{ $tag->tag }}</p>
                                 @endforeach
                             </div>
+                            <div class="image">
+                                <img src="{{ $note->image_url }}" alt="画像が読み込めません。"/>
+                            </div>
                          </div>
                     </div>
                 </div>

--- a/resources/views/notes/show.blade.php
+++ b/resources/views/notes/show.blade.php
@@ -42,9 +42,11 @@
                                     <p>{{ $tag->tag }}</p>
                                 @endforeach
                             </div>
+                            @if ($note->image_url)
                             <div class="image">
                                 <img src="{{ $note->image_url }}" alt="画像が読み込めません。"/>
                             </div>
+                            @endif
                          </div>
                     </div>
                 </div>


### PR DESCRIPTION
## 概要
[Cloudinary](https://cloudinary.com/)を使用して、ノートに画像アップロード機能を実装した。
## 変更点
- 環境構築
  - [README](https://github.com/cloudinary-devs/cloudinary-laravel#installation)を参考に環境を構築した。
- 画像URLを保存するカラムを追加
  - `notes`テーブルに`image_url`カラムを追加。null値を許容して画像なしでもノートを保存できるようにしている
- 保存処理
  - `NoteRequest`にバリデーションルールを追加。2MB以上のファイルに対してエラーを返す。
  - `NoteController`にCloudinaryのuse宣言を記述
  - コントローラメソッド`store`に処理を追加。
    - 画像ファイルがある場合、`getRealPath()`でファイルの絶対パスを取得して`upload()`でCloudinaryに保存する