### PR TITLE
Feat #22 operate in session

### DIFF
--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -15,8 +15,28 @@ class NoteController extends Controller
     /**
      * ノート一覧画面
      */
-    public function index(Note $note)
+    public function index(Request $request, Note $note)
     {
+        if ($request->has('cancel_notetake')) {
+            // sessionからvolumeキー、chapterキーの値を取得
+            $volumes = session('volume', []);
+            $chapters = session('chapter', []);
+            
+            $key_to_delete = []; // 削除するセッションキーの配列
+            
+            foreach ($volumes as $volume) {
+                foreach ($chapters as $chapter) {
+                    $key = 'ids_' . $volume . '_' . $chapter;
+                    $keys_to_delete[] = $key;
+                }
+            }
+            
+            $unique_key_to_delete = array_merge($keys_to_delete); // 重複するキーを削除
+            // 配列に保存されたセッションキーを一括で削除
+            session()->forget($unique_key_to_delete);
+            session()->forget(['volume', 'chapter', 'testament_array']);
+        }
+        
         $notes = $note->get();
         return view('notes.index')->with(['notes' => $note->get()]);
     }
@@ -82,32 +102,69 @@ class NoteController extends Controller
      * $public_valueは、ラジオボタンのchecked属性を動的に制御するために用意
      */
     public function create(Request $request, Tag $tag)
-    {
-        // 直前にアクセスしたリンクに戻るための$testamentデータ
-        $testamentValue = $request->query('ids');
-        $last_selected_testament = Testament::where('id', $testamentValue)->first();
+    {   
+        if ($request->has('ids')) {
+            // 直前にアクセスしたリンクに戻るために$testamentデータからvolumeとchapterを取得
+            $testament_value = $request->query('ids');
+            $last_selected_testament = Testament::where('id', $testament_value)->first();
+            $volume = [$last_selected_testament->volume->id];
+            $chapter = [$last_selected_testament->chapter];
 
-        // Sessionにリクエストデータtestament_arrayを保存する処理
-        $selected_testaments = $request->query('ids', []); // リクエストデータからtestament_arrayを取得
-        $existing_testaments = session('ids', []); // Sessionに保存されている既存のtestament_arrayを取得
+            // Sessionに$volumeを保存する処理
+            $existing_volume = session('volume', []); // 既存のvolumeの配列を変数に格納
+            $merged_volume = array_merge($existing_volume, $volume); // リクエストデータのvolume番号を既存のvolume配列に追加
+            $unique_volume = array_unique($merged_volume); // 重複を除いたユニークな値のみを取得
+            session(['volume' => $unique_volume]);
         
-        $merged_testaments = array_merge($existing_testaments, $selected_testaments); // 新しい選択されたtestamentsを既存のtestament_arrayに追加
-        $unique_testaments = array_unique($merged_testaments); // 重複を除いたユニークな値のみを取得
-        session(['ids' => $unique_testaments]); // Sessionに更新したtestament_arrayを保存
+            // Sessionに$chapterを保存する処理
+            $existing_chapter = session('chapter', []); // 既存のchapterの配列を変数に格納
+            $merged_chapter = array_merge($existing_chapter, $chapter); // リクエストデータのchapterを既存のchapter配列に追加
+            $unique_chapter = array_unique($merged_chapter); // 重複を除いたユニークな値のみを取得
+            session(['chapter' => $unique_chapter]);
         
-        $all_session_data = session('ids', []); //デバックのためのデータ
+            // Sessionにリクエストデータidsを保存する処理
+            $session_key = 'ids_' . $volume[0] . '_' . $chapter[0];
+            $selected_testaments = $request->query('ids', []); // リクエストデータからtestament_arrayを取得
+            session([$session_key => $selected_testaments]); // sessionの指定したキーにリクエストデータを上書き
+            
+            //ページたびに保存されたidsを取り出し、1つの配列に保存する
+            // volume と chapter の ID を使用して処理
+            $testament_array = [];
+        
+            $volumes = session('volume', []);
+            $chapters = session('chapter', []);
+            
+            foreach ($volumes as $volume) {
+                foreach ($chapters as $chapter) {
+                    $key = 'ids_' . $volume . '_' . $chapter;
+        
+                    // session から値を取得し、処理を行う
+                    $testament_per_key = session($key, []);
+        
+                    // $testament_per_key の値を $testament_array にマージ
+                    $testament_array = array_merge($testament_array, $testament_per_key);
+                }
+            }
+        
+            // $testamentArray を testament_array キーで session に保存
+            session(['testament_array' => $testament_array]);
+        }
     
-        // 更新したtestament_arrayを使ってTestamentモデルからデータを取得
-        $testaments = Testament::whereIn('id', $unique_testaments)->get();
+        // session から testament_array を取得して Testaments を取得
+        $testaments = Testament::whereIn('id', session('testament_array', []))->get();
     
         $public_value = 'true';
+        
+        // セッション内のすべてのデータを取得する（デバック）
+        $all_session_data = session()->all();
     
         return view('notes.create')->with([
             'public_value' => $public_value,
             'tags' => $tag->get(),
-            'all_session_data' => $all_session_data,
             'testaments' => $testaments,
-            'last_selected_testament' => $last_selected_testament,
+            'session_testaments_data' => $testaments, //デバック
+            'last_selected_testament' => $last_selected_testament ?? null,
+            'all_session_data' => $all_session_data, //デバック
         ]);
     }
     
@@ -134,7 +191,25 @@ class NoteController extends Controller
          $note->testaments()->attach($input_testaments);
          $note->tags()->attach($input_tags);
          
-         session()->forget('ids'); // 既存のtestament_arrayを初期化
+         // sessionに保存していたデータを消去する
+         // sessionからvolumeキー、chapterキーの値を取得
+         $volumes = session('volume', []);
+         $chapters = session('chapter', []);
+        
+         $key_to_delete = []; // 削除するセッションキーの配列
+        
+         foreach ($volumes as $volume) {
+             foreach ($chapters as $chapter) {
+                 $key = 'ids_' . $volume . '_' . $chapter;
+                 $keys_to_delete[] = $key;
+             }
+         }
+        
+         $unique_key_to_delete = array_merge($keys_to_delete); // 重複するキーを削除
+         // 配列に保存されたセッションキーを一括で削除
+         session()->forget($unique_key_to_delete);
+         session()->forget(['volume', 'chapter', 'testament_array']);
+         
          return redirect(route('notes.index'));
      }
      

--- a/app/Http/Controllers/TestamentController.php
+++ b/app/Http/Controllers/TestamentController.php
@@ -41,6 +41,9 @@ class TestamentController extends Controller
         
         $chapter_set = $contents->first();
         
+        $selected_testaments = session('ids', []); //Sessionからすでに選ばれた配列を取得
+        $testament_id = collect($selected_testaments); // Collectionに変換
+        
         // 最小のchapterを取得
         $earliest_chapter = $testament->getChapter($volume, false);
         
@@ -55,6 +58,7 @@ class TestamentController extends Controller
             'chapter' => $chapter,
             'testaments' => $contents,
             'chapter_set' => $chapter_set,
+            'testament_id' => $testament_id,
             'latest_chapter' => $latest_chapter, 
             'earliest_chapter' => $earliest_chapter,
             'previous_volume_latest_chapter' => $previous_volume_latest_chapter]);

--- a/app/Http/Controllers/TestamentController.php
+++ b/app/Http/Controllers/TestamentController.php
@@ -41,7 +41,7 @@ class TestamentController extends Controller
         
         $chapter_set = $contents->first();
         
-        $selected_testaments = session('ids', []); //Sessionからすでに選ばれた配列を取得
+        $selected_testaments = session('ids_' . $volume . '_' . $chapter, []); //Sessionからすでに選ばれた配列を取得
         $testament_id = collect($selected_testaments); // Collectionに変換
         
         // 最小のchapterを取得

--- a/resources/views/notes/create.blade.php
+++ b/resources/views/notes/create.blade.php
@@ -13,21 +13,26 @@
                     <div class="p-6 text-gray-900">
                         <form action="/notes" method="POST" enctype="multipart/form-data">
                             @csrf
-                            <div class="testament">
-                                <label>
-                                    <input type="radio" value="1" name="note[public]" {{ $public_value == true ? 'checked' : '' }}>
-                                    公開ノート
-                                </label>
-                                <label>
-                                    <input type="radio" value="0" name="note[public]" {{ $public_value == false ? 'checked' : '' }}>
-                                    非公開ノート
-                                </label>
-                                <br>
+                            <label>
+                                <input type="radio" value="1" name="note[public]" {{ $public_value == true ? 'checked' : '' }}>
+                                公開ノート
+                            </label>
+                            <label>
+                                <input type="radio" value="0" name="note[public]" {{ $public_value == false ? 'checked' : '' }}>
+                                非公開ノート
+                            </label>
+                            <br>
+                            <div class="testaments">
                                 <h2>聖句</h2>
                                 @foreach ($testaments as $testament)
                                     <input type="hidden" name="testaments_array[]" value="{{ $testament->id }}">
                                     <p>{{ $testament->text }}</p>
                                 @endforeach
+                                @if (count($testaments) === 0 or !$last_selected_testament)
+                                <a href="/testaments">聖句を追加</a>
+                                @else
+                                <a href="/testaments/volume{{ $last_selected_testament->volume->id }}/chapter{{ $last_selected_testament->chapter }}">聖句を追加</a>
+                                @endif
                                 <br>
                             </div>
                             <div class="title">
@@ -62,5 +67,8 @@
         </div>
         <!-- デバックステップ: oldヘルパーの動作確認 -->
         <pre><code>{{ var_dump(session()->get('_old_input')) }}</code></pre>
+        @foreach($all_session_data as $key => $value)
+            <p>{{ $key }}: {{ $value }}</p>
+        @endforeach
     </body>
 </x-app-layout>

--- a/resources/views/notes/create.blade.php
+++ b/resources/views/notes/create.blade.php
@@ -23,7 +23,6 @@
                             </label>
                             <br>
                             <div class="testaments">
-                                <h2>聖句</h2>
                                 @foreach ($testaments as $testament)
                                     <input type="hidden" name="testaments_array[]" value="{{ $testament->id }}">
                                     <p>{{ $testament->text }}</p>
@@ -60,6 +59,7 @@
                                 <p class="image__error" style="color:red">{{ $errors->first('image') }}</p>
                             </div>
                             <input type="submit" value="保存する"/>
+                            <a href="/notes?cancel_notetake=true">キャンセル</a>
                         </form>
                     </div>
                 </div>
@@ -67,8 +67,9 @@
         </div>
         <!-- デバックステップ: oldヘルパーの動作確認 -->
         <pre><code>{{ var_dump(session()->get('_old_input')) }}</code></pre>
-        @foreach($all_session_data as $key => $value)
+        @foreach($session_testaments_data as $key => $value)
             <p>{{ $key }}: {{ $value }}</p>
         @endforeach
+        {{ var_dump($all_session_data) }}
     </body>
 </x-app-layout>

--- a/resources/views/notes/edit.blade.php
+++ b/resources/views/notes/edit.blade.php
@@ -8,16 +8,16 @@
         <form action="/notes/{{ $note->id }}" method="POST">
             @csrf
             @method('PUT')
+            <label>
+                <input type="radio" value="1" name="note[public]" {{ $public_value == true ? 'checked' : '' }}>
+                公開ノート
+            </label>
+            <label>
+                <input type="radio" value="0" name="note[public]" {{ $public_value == false ? 'checked' : '' }}>
+                非公開ノート
+            </label>
+            <br>
             <div class="testament">
-                <label>
-                    <input type="radio" value="1" name="note[public]" {{ $public_value == true ? 'checked' : '' }}>
-                    公開ノート
-                </label>
-                <label>
-                    <input type="radio" value="0" name="note[public]" {{ $public_value == false ? 'checked' : '' }}>
-                    非公開ノート
-                </label>
-                <br>
                 <h2>聖句</h2>
                 @foreach ($testaments as $testament)
                     <lavel>

--- a/resources/views/testaments/show.blade.php
+++ b/resources/views/testaments/show.blade.php
@@ -13,7 +13,7 @@
                         <div class="p-6 text-gray-900">
                             <h2>{{ $chapter_set->volume->title }}: 第{{ $chapter_set->chapter }}章</h2>
                             @foreach ($testaments as $testament)
-                                <input type="checkbox" value={{ $testament->id }} name="testaments_array[]">
+                                <input type="checkbox" value={{ $testament->id }} name="ids[]" {{ $testament_id->contains($testament->id) ? 'checked' : '' }}>
                                 <small>{{ $testament->section }}</small> {{ $testament->text }}<br>
                             @endforeach
                         </div>
@@ -53,16 +53,16 @@
             e.preventDefault(); // デフォルトのリンク挙動を無効化
         
             // 選択されたチェックボックスの値を収集
-            var selectedTestaments = document.querySelectorAll('input[name="testaments_array[]"]:checked');
+            var selectedTestaments = document.querySelectorAll('input[name="ids[]"]:checked');
             var values = [];
-            selectedTestaments.forEach(function(testament) {
-                values.push(testament.value);
+            selectedTestaments.forEach(function(id) {
+                values.push(id.value);
             });
         
             // チェックボックスが1つ以上選択されている場合
             if (values.length > 0) {
                 // クエリパラメータを作成
-                var queryString = 'testaments_array[]=' + values.join('&testaments_array[]=');
+                var queryString = 'ids[]=' + values.join('&ids[]=');
                 
                 // GETリクエストを送信するURLを作成
                 var url = '/notes/create?' + queryString;

--- a/resources/views/testaments/show.blade.php
+++ b/resources/views/testaments/show.blade.php
@@ -8,7 +8,7 @@
             <div class="py-12">
                 <a href="/testaments">Home</a> > <a href="/testaments/volume{{ $volume }}">Volume {{ $volume }}</a> > <span>Chapter {{ $chapter }}</span>
                 <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                    <a href="#" id="sendData">ノートを作成する</a>
+                    <a href="#" id="sendData">選択した聖句からノートを作成する</a>
                     <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                         <div class="p-6 text-gray-900">
                             <h2>{{ $chapter_set->volume->title }}: 第{{ $chapter_set->chapter }}章</h2>


### PR DESCRIPTION
## 概要
- セッションを使って、特定の処理が実行されるまで聖句の内容を保持できるようにした。
- セッションにページごとの聖句を保持できることで、他のvolume、他の章の聖句を閲覧画面から選び、ノートに保存できるようになった。
## 変更点
- コントローラメソッドに処理を追加。聖書閲覧画面から送られたURLのクエリパラメータ`ids`をsessionに保存・削除する
    - `NoteController`の`create`メソッドに、`ids`をページごとにキーで振り分けて保存する処理を追加した。
      - GETリクエストを送ってきたURL元の`$volume`と`$chapter`を取得して、それを元にページごとのセッションキーを生成あるいは指定して、`ids`を上書きする。また、その後の処理のために`$volume`と`$chapter`をそれぞれ指定のキーに追加する。
      - ページごとに保存した`ids`を、sessionの`testament_array`に保存する。
      - `testament_array`の`ids`の値と同一の`testaments`テーブルの`id`を取得する。
    - `store`メソッドと`show`メソッドにsessionの値を削除する処理を追加
      -  保存処理やノート作成のキャンセルリンクをクリックすると、処理が実行される。
      - `forget()`で保持していた値を削除する。
## やり残したこと
- この変更をノートの編集処理とコメントの作成処理・編集処理にも適用する必要があるが、まだやっていない。