### PR TITLE
Feat #22 apply to others

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -12,24 +12,104 @@ class CommentController extends Controller
     /**
      * コメント一覧表示
      */
-    public function index($note, Comment $comment, Testament $testament)
+    public function index($note, Comment $comment, Request $request)
     {
+        if ($request->has('cancel_comment_take')) {
+            // sessionからvolumeキー、chapterキーの値を取得
+            $volumes = session('volume', []);
+            $chapters = session('chapter', []);
+            
+            $keys_to_delete = []; // 削除するセッションキーの配列
+            
+            foreach ($volumes as $volume) {
+                foreach ($chapters as $chapter) {
+                    $key = 'ids_' . $volume . '_' . $chapter;
+                    $keys_to_delete[] = $key;
+                }
+            }
+            
+            $unique_keys_to_delete = array_unique($keys_to_delete); // 重複するキーを削除
+            // 配列に保存されたセッションキーを一括で削除
+            session()->forget($unique_keys_to_delete);
+            session()->forget([
+             'comment_creating',
+             'note_editing,',
+             'volume',
+             'chapter',
+             'testament_array',
+             ]);
+        }
+        
+        if (!session()->has('comment_creating')) {
+            session(['comment_creating' => $note]);
+        }
+        
+        // クエリパラメータidsが送られた場合の処理
+        if ($request->has('ids')) {
+            // 直前にアクセスしたリンクに戻るために$testamentデータからvolumeとchapterを取得
+            $testament_value = $request->query('ids');
+            $last_selected_testament = Testament::where('id', $testament_value)->first();
+            $volume = [$last_selected_testament->volume->id];
+            $chapter = [$last_selected_testament->chapter];
+
+            // Sessionに$volumeを保存する処理
+            $existing_volume = session('volume', []); // 既存のvolumeの配列を変数に格納
+            $merged_volume = array_merge($existing_volume, $volume); // リクエストデータのvolume番号を既存のvolume配列に追加
+            $unique_volume = array_unique($merged_volume); // 重複を除いたユニークな値のみを取得
+            session(['volume' => $unique_volume]);
+        
+            // Sessionに$chapterを保存する処理
+            $existing_chapter = session('chapter', []); // 既存のchapterの配列を変数に格納
+            $merged_chapter = array_merge($existing_chapter, $chapter); // リクエストデータのchapterを既存のchapter配列に追加
+            $unique_chapter = array_unique($merged_chapter); // 重複を除いたユニークな値のみを取得
+            session(['chapter' => $unique_chapter]);
+        
+            // Sessionにリクエストデータidsを保存する処理
+            $session_key = 'ids_' . $volume[0] . '_' . $chapter[0];
+            $selected_testaments = $request->query('ids', []); // リクエストデータからidsを取得
+            session([$session_key => $selected_testaments]); // sessionの指定したキーにリクエストデータを上書き
+            
+            //ページたびに保存されたidsを取り出し、1つの配列に保存する
+            // volume と chapter の ID を使用して処理
+            $testament_array = [];
+        
+            $volumes = session('volume', []);
+            $chapters = session('chapter', []);
+            
+            foreach ($volumes as $volume) {
+                foreach ($chapters as $chapter) {
+                    $key = 'ids_' . $volume . '_' . $chapter;
+        
+                    // session から値を取得し、処理を行う
+                    $testament_per_key = session($key, []);
+        
+                    // $testament_per_key の値を $testament_array にマージ
+                    $testament_array = array_merge($testament_array, $testament_per_key);
+                }
+            }
+        
+            // $testamentArray を testament_array キーで session に保存
+            session(['testament_array' => $testament_array]);
+        }
+        
+        //sessionに保存されたtestament_arrayの値と等しいtestamentsから取得
+        $testaments = Testament::whereIn('id', session('testament_array', []))->get();
+        
         // 特定のnote_idに関連するコメントを取得するクエリを実行
         $comments = $comment::where('note_id', $note)->get();
-        
-        $comment_testament = $testament->get();
         
         return view('notes.comments.index')->with([
             'note_id' => $note,
             'comments' => $comments,
-            'comment_testaments' => $comment_testament,
+            'testaments' => $testaments,
+            'last_selected_testament' => $last_selected_testament ?? null,
             ]);
     }
      
     /**
      * コメント保存処理
      */
-    public function store(Comment $comment, Testament $testament, CommentRequest $request)
+    public function store(Comment $comment, CommentRequest $request)
     {
         $input_comment = $request['new_comment'];
         $input_testaments = $request->testaments_array;
@@ -39,30 +119,154 @@ class CommentController extends Controller
         
         $comment->testaments()->attach($input_testaments);
         
+        // sessionに保存していたデータを消去する
+         // sessionからvolumeキー、chapterキーの値を取得
+         $volumes = session('volume', []);
+         $chapters = session('chapter', []);
+        
+         $key_to_delete = []; // 削除するセッションキーの配列
+        
+         foreach ($volumes as $volume) {
+             foreach ($chapters as $chapter) {
+                 $key = 'ids_' . $volume . '_' . $chapter;
+                 $keys_to_delete[] = $key;
+             }
+         }
+        
+         $unique_key_to_delete = array_unique($keys_to_delete); // 重複するキーを削除
+         // 配列に保存されたセッションキーを一括で削除
+         session()->forget($unique_key_to_delete);
+         session()->forget([
+             'comment_editing',
+             'comment_creating',
+             'note_editing,',
+             'volume',
+             'chapter',
+             'testament_array',
+             ]);
+        
         return redirect('/notes/' . $comment->note_id . '/comments');
     }
     
     /**
      * コメント編集処理
      */
-    public function edit($note, $comment, Testament $testament)
+    public function edit($note, $comment, Request $request)
     {
         $edit_comment = Comment::find($comment);
         
-        $testament_id = $edit_comment->testaments->pluck('id');
+        if (session()->has('comment_creating')) {
+            session()->forget('comment_creating');
+        }
+        
+        // sessionに編集中のデータがない場合の処理
+          if (!session()->has('comment_editing')) {
+              // 編集するコメントのtestamentsをsessionに保存する
+              // 特定の$commentに関連付けられたtestamentsからvolume_idとchapterの一意な値を抽出
+              // それらの組み合わせごとに一致するtestamentsのidをセッションに保存する
+              $value = [$note, $comment];
+              session(['comment_editing' => $value]); // sessionに編集しているnote、commentのidを保存
+              
+              $comment_volumes = $edit_comment->testaments->pluck('volume_id')->toArray(); // $commentの持つtestamentsのvolume_idを配列で取得
+              $comment_chapters = $edit_comment->testaments->pluck('chapter')->toArray(); // $commentの持つtestamentsのchapterを配列で取得
+              
+              // 重複のない配列に変換
+              $unique_comment_volumes = array_unique($comment_volumes);
+              $unique_comment_chapters = array_unique($comment_chapters);
+              
+              // それぞれをsessionの指定したキーに保存
+              session(['volume' => $unique_comment_volumes]);
+              session(['chapter' => $unique_comment_chapters]);
+              
+              // volume_idとchapterごとにtestamentsのidを振り分けて保存する
+              // 合わせて、すべてのtestamentsのidをtestament_arrayに保存する
+              $comment_testaments = $edit_comment->testaments; // $commentの持つtestamentsを取得
+              
+              $comment_testament_array = []; //すべてのidを代入する配列
+              
+              foreach ($unique_comment_volumes as $comment_volume) {
+                  foreach ($unique_comment_chapters as $comment_chapter) {
+                      // 変数に基づいてキーを生成
+                      $comment_session_key = 'ids_' . $comment_volume . '_' .$comment_chapter;
+                      // $commentの持つtestamentから指定した条件でidを取得して、配列に変換
+                      $filtered_id = $comment_testaments->where('volume_id', $comment_volume)
+                                             ->where('chapter', $comment_chapter)
+                                             ->pluck('id')
+                                             ->toArray();
+                      
+                      if (!empty($filtered_id)) {
+                          session([$comment_session_key => $filtered_id]); //idをsessionの特定のキーに保存
+                      }
+                      $comment_testament_array = array_merge($comment_testament_array, $filtered_id);
+                  }
+              }
+              
+              session(['testament_array' => $comment_testament_array]); //testament_arrayにすべてのidを保存
+          }
+        
+        // クエリパラメータidsが送られた場合の処理
+          if ($request->has('ids')) {
+                // 直前にアクセスしたリンクに戻るために$testamentデータからvolumeとchapterを取得
+                $testament_value = $request->query('ids');
+                $last_selected_testament = Testament::where('id', $testament_value)->first();
+                $volume = [$last_selected_testament->volume->id];
+                $chapter = [$last_selected_testament->chapter];
+    
+                // sessionに$volumeを保存する処理
+                $existing_volume = session('volume', []); // 既存のvolumeの配列を変数に格納
+                $merged_volume = array_merge($existing_volume, $volume); // リクエストデータのvolume番号を既存のvolume配列に追加
+                $unique_volume = array_unique($merged_volume); // 重複を除いたユニークな値のみを取得
+                session(['volume' => $unique_volume]);
+            
+                // Sessionに$chapterを保存する処理
+                $existing_chapter = session('chapter', []); // 既存のchapterの配列を変数に格納
+                $merged_chapter = array_merge($existing_chapter, $chapter); // リクエストデータのchapterを既存のchapter配列に追加
+                $unique_chapter = array_unique($merged_chapter); // 重複を除いたユニークな値のみを取得
+                session(['chapter' => $unique_chapter]);
+            
+                // Sessionにリクエストデータidsを保存する処理
+                $session_key = 'ids_' . $volume[0] . '_' . $chapter[0];
+                $selected_testaments = $request->query('ids', []); // リクエストデータからidsを取得
+                session([$session_key => $selected_testaments]); // sessionの指定したキーにリクエストデータを上書き
+                
+                //ページごとに保存されたidsを取り出し、1つの配列に保存する
+                // volumeとchapterのidを使用して処理
+                $testament_array = [];
+            
+                $volumes = session('volume', []);
+                $chapters = session('chapter', []);
+                
+                foreach ($volumes as $volume) {
+                    foreach ($chapters as $chapter) {
+                        $key = 'ids_' . $volume . '_' . $chapter;
+            
+                        // session から値を取得し、処理を行う
+                        $testament_per_key = session($key, []);
+            
+                        // $testament_per_key の値を $testament_array にマージ
+                        $testament_array = array_merge($testament_array, $testament_per_key);
+                    }
+                }
+            
+                // $testamentArray を testament_array キーで session に保存
+                session(['testament_array' => $testament_array]);
+            }
+        
+        //sessionに保存されたtestament_arrayの値と等しいtestamentsから取得
+        $testaments = Testament::whereIn('id', session('testament_array', []))->get();
         
         return view('notes.comments.edit')->with([
             'note_id' => $note,
             'comment' => $edit_comment,
-            'testament_id' => $testament_id,
-            'testaments' => $testament->get(),
+            'testaments' => $testaments,
+            'last_selected_testament' => $last_selected_testament ?? null,
             ]);
     }
     
     /**
      * コメント更新処理
      */
-    public function update($note, $comment, Testament $testament, CommentRequest $request)
+    public function update($note, $comment, CommentRequest $request)
     {
         $input_comment = $request['new_comment'];
         $input_testaments = $request->testaments_array;
@@ -73,6 +277,32 @@ class CommentController extends Controller
         $edited_comment->fill($input_comment)->save();
         
         $edited_comment->testaments()->sync($input_testaments);
+        
+        // sessionに保存していたデータを消去する
+          // sessionからvolumeキー、chapterキーの値を取得
+          $volumes = session('volume', []);
+          $chapters = session('chapter', []);
+        
+          $key_to_delete = []; // 削除するセッションキーの配列
+        
+          foreach ($volumes as $volume) {
+              foreach ($chapters as $chapter) {
+                  $key = 'ids_' . $volume . '_' . $chapter;
+                  $keys_to_delete[] = $key;
+              }
+          }
+        
+          $unique_key_to_delete = array_unique($keys_to_delete); // 重複するキーを削除
+          // 配列に保存されたセッションキーを一括で削除
+          session()->forget($unique_key_to_delete);
+          session()->forget([
+             'comment_editing',
+             'comment_creating',
+             'note_editing,',
+             'volume',
+             'chapter',
+             'testament_array',
+             ]);
         
         return redirect('/notes/' . $note . '/comments');
     }

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -22,7 +22,7 @@ class NoteController extends Controller
             $volumes = session('volume', []);
             $chapters = session('chapter', []);
             
-            $key_to_delete = []; // 削除するセッションキーの配列
+            $keys_to_delete = []; // 削除するセッションキーの配列
             
             foreach ($volumes as $volume) {
                 foreach ($chapters as $chapter) {
@@ -31,9 +31,9 @@ class NoteController extends Controller
                 }
             }
             
-            $unique_key_to_delete = array_merge($keys_to_delete); // 重複するキーを削除
+            $unique_keys_to_delete = array_merge($keys_to_delete); // 重複するキーを削除
             // 配列に保存されたセッションキーを一括で削除
-            session()->forget($unique_key_to_delete);
+            session()->forget($unique_keys_to_delete);
             session()->forget(['volume', 'chapter', 'testament_array']);
         }
         
@@ -103,6 +103,7 @@ class NoteController extends Controller
      */
     public function create(Request $request, Tag $tag)
     {   
+        // クエリパラメータidsが送られた場合の処理
         if ($request->has('ids')) {
             // 直前にアクセスしたリンクに戻るために$testamentデータからvolumeとchapterを取得
             $testament_value = $request->query('ids');
@@ -124,7 +125,7 @@ class NoteController extends Controller
         
             // Sessionにリクエストデータidsを保存する処理
             $session_key = 'ids_' . $volume[0] . '_' . $chapter[0];
-            $selected_testaments = $request->query('ids', []); // リクエストデータからtestament_arrayを取得
+            $selected_testaments = $request->query('ids', []); // リクエストデータからidsを取得
             session([$session_key => $selected_testaments]); // sessionの指定したキーにリクエストデータを上書き
             
             //ページたびに保存されたidsを取り出し、1つの配列に保存する
@@ -150,12 +151,12 @@ class NoteController extends Controller
             session(['testament_array' => $testament_array]);
         }
     
-        // session から testament_array を取得して Testaments を取得
+        //sessionに保存されたtestament_arrayの値と等しいtestamentsから取得
         $testaments = Testament::whereIn('id', session('testament_array', []))->get();
     
         $public_value = 'true';
         
-        // セッション内のすべてのデータを取得する（デバック）
+        // セッション内のすべてのデータを取得する（デバック)
         $all_session_data = session()->all();
     
         return view('notes.create')->with([
@@ -216,23 +217,118 @@ class NoteController extends Controller
      /**
       * ノート編集画面
       */
-      public function edit(Note $note, Tag $tag, Testament $testament)
+      public function edit(Note $note, Tag $tag, Request $request)
       {
+          // sessionに編集中のデータがない場合の処理
+          if (!session()->has('editing')) {
+              // 編集するノートのtestamentsをsessionに保存する
+              // 特定の$noteに関連付けられたtestamentsからvolume_idとchapterの一意な値を抽出
+              // それらの組み合わせごとに一致するtestamentsのidをセッションに保存する
+              $note_id = $note->id;
+              session(['editing' => $note_id]); // sessionに編集しているnoteのidを保存
+              
+              $note_volumes = $note->testaments->pluck('volume_id')->toArray(); // $noteの持つtestamentsのvolume_idを配列で取得
+              $note_chapters = $note->testaments->pluck('chapter')->toArray(); // $noteの持つtestamentsのchapterを配列で取得
+              
+              // 重複のない配列に変換
+              $unique_note_volumes = array_unique($note_volumes);
+              $unique_note_chapters = array_unique($note_chapters);
+              
+              // それぞれをsessionの指定したキーに保存
+              session(['volume' => $unique_note_volumes]);
+              session(['chapter' => $unique_note_chapters]);
+              
+              // volume_idとchapterごとにtestamentsのidを振り分けて保存する
+              // 合わせて、すべてのtestamentsのidをtestament_arrayに保存する
+              $note_testaments = $note->testaments; //noteの持つtestamentsを取得
+              
+              $note_testament_array = []; //すべてのidを代入する配列
+              
+              foreach ($unique_note_volumes as $note_volume) {
+                  foreach ($unique_note_chapters as $note_chapter) {
+                      // 変数に基づいてキーを生成
+                      $note_session_key = 'ids_' . $note_volume . '_' .$note_chapter;
+                      // noteの持つtestamentから指定した条件でidを取得して、配列に変換
+                      $filtered_id = $note_testaments->where('volume_id', $note_volume)
+                                             ->where('chapter', $note_chapter)
+                                             ->pluck('id')
+                                             ->toArray();
+                      
+                      if (!empty($filtered_id)) {
+                          session([$note_session_key => $filtered_id]); //idをsessionの特定のキーに保存
+                      }
+                      $note_testament_array = array_merge($note_testament_array, $filtered_id);
+                  }
+              }
+              
+              session(['testament_array' => $note_testament_array]); //testament_arrayにすべてのidを保存
+          }
+          
+          // クエリパラメータidsが送られた場合の処理
+          if ($request->has('ids')) {
+                // 直前にアクセスしたリンクに戻るために$testamentデータからvolumeとchapterを取得
+                $testament_value = $request->query('ids');
+                $last_selected_testament = Testament::where('id', $testament_value)->first();
+                $volume = [$last_selected_testament->volume->id];
+                $chapter = [$last_selected_testament->chapter];
+    
+                // sessionに$volumeを保存する処理
+                $existing_volume = session('volume', []); // 既存のvolumeの配列を変数に格納
+                $merged_volume = array_merge($existing_volume, $volume); // リクエストデータのvolume番号を既存のvolume配列に追加
+                $unique_volume = array_unique($merged_volume); // 重複を除いたユニークな値のみを取得
+                session(['volume' => $unique_volume]);
+            
+                // Sessionに$chapterを保存する処理
+                $existing_chapter = session('chapter', []); // 既存のchapterの配列を変数に格納
+                $merged_chapter = array_merge($existing_chapter, $chapter); // リクエストデータのchapterを既存のchapter配列に追加
+                $unique_chapter = array_unique($merged_chapter); // 重複を除いたユニークな値のみを取得
+                session(['chapter' => $unique_chapter]);
+            
+                // Sessionにリクエストデータidsを保存する処理
+                $session_key = 'ids_' . $volume[0] . '_' . $chapter[0];
+                $selected_testaments = $request->query('ids', []); // リクエストデータからidsを取得
+                session([$session_key => $selected_testaments]); // sessionの指定したキーにリクエストデータを上書き
+                
+                //ページごとに保存されたidsを取り出し、1つの配列に保存する
+                // volumeとchapterのidを使用して処理
+                $testament_array = [];
+            
+                $volumes = session('volume', []);
+                $chapters = session('chapter', []);
+                
+                foreach ($volumes as $volume) {
+                    foreach ($chapters as $chapter) {
+                        $key = 'ids_' . $volume . '_' . $chapter;
+            
+                        // session から値を取得し、処理を行う
+                        $testament_per_key = session($key, []);
+            
+                        // $testament_per_key の値を $testament_array にマージ
+                        $testament_array = array_merge($testament_array, $testament_per_key);
+                    }
+                }
+            
+                // $testamentArray を testament_array キーで session に保存
+                session(['testament_array' => $testament_array]);
+            }
+          
+          //sessionに保存されたtestament_arrayの値と等しいtestamentsから取得
+          $testaments = Testament::whereIn('id', session('testament_array', []))->get();
+            
           $public_value = $note->public;
           // pluckメソッドでidカラムの値を抽出
-          $testament_id = $note->testaments->pluck('id');
           $tag_id = $note->tags->pluck('id');
           
           return view('notes.edit')->with([
               'public_value' => $public_value,
-              'testament_id' => $testament_id,
               'tag_id' => $tag_id,
               'note' => $note,
               'tags' => $tag->get(),
-              'testaments' => $testament->get(),
+              'testaments' => $testaments,
+              'last_selected_testament' => $last_selected_testament ?? null,
               ]);
       }
-      
+       
      /**
       * ノート更新処理
       */
@@ -248,6 +344,25 @@ class NoteController extends Controller
           // 関連データを更新するために sync() メソッドを使用する
           $note->testaments()->sync($input_testaments);
           $note->tags()->sync($input_tags);
+          
+          // sessionに保存していたデータを消去する
+          // sessionからvolumeキー、chapterキーの値を取得
+          $volumes = session('volume', []);
+          $chapters = session('chapter', []);
+        
+          $key_to_delete = []; // 削除するセッションキーの配列
+        
+          foreach ($volumes as $volume) {
+              foreach ($chapters as $chapter) {
+                  $key = 'ids_' . $volume . '_' . $chapter;
+                  $keys_to_delete[] = $key;
+              }
+          }
+        
+          $unique_key_to_delete = array_merge($keys_to_delete); // 重複するキーを削除
+          // 配列に保存されたセッションキーを一括で削除
+          session()->forget($unique_key_to_delete);
+          session()->forget(['editing', 'volume', 'chapter', 'testament_array']);
           
           return redirect('/notes/' . $note->id);
       }

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -50,7 +50,7 @@ class NoteController extends Controller
      */
      public function show(Note $note)
      {
-         $testaments_query_builder = $note->testaments;
+         $testaments_query_builder = $note->testaments->sortBy('id');
          
          // volume_id をキーとし、その下に chapter をキーとした testaments の多重連想配列
          $testaments_by_volume_and_chapter = $testaments_query_builder->groupBy('volume_id')->map(function ($testaments) {
@@ -90,7 +90,7 @@ class NoteController extends Controller
                  }
              }
          }
-
+        
          return view('notes.show')->with([
              'testaments_by_volume_and_chapter' => $testaments_by_volume_and_chapter,
              'section_info_by_volume' => $section_info_by_volume,

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -17,7 +17,7 @@ class NoteController extends Controller
      */
     public function index(Request $request, Note $note)
     {
-        if ($request->has('cancel_notetake')) {
+        if ($request->has('cancel_note_take')) {
             // sessionからvolumeキー、chapterキーの値を取得
             $volumes = session('volume', []);
             $chapters = session('chapter', []);
@@ -34,7 +34,13 @@ class NoteController extends Controller
             $unique_keys_to_delete = array_unique($keys_to_delete); // 重複するキーを削除
             // 配列に保存されたセッションキーを一括で削除
             session()->forget($unique_keys_to_delete);
-            session()->forget(['editing', 'volume', 'chapter', 'testament_array']);
+            session()->forget([
+             'comment_creating',
+             'note_editing,',
+             'volume',
+             'chapter',
+             'testament_array',
+             ]);
         }
         
         return view('notes.index')->with(['notes' => $note->get()]);
@@ -208,7 +214,14 @@ class NoteController extends Controller
          $unique_key_to_delete = array_unique($keys_to_delete); // 重複するキーを削除
          // 配列に保存されたセッションキーを一括で削除
          session()->forget($unique_key_to_delete);
-         session()->forget(['volume', 'chapter', 'testament_array']);
+         session()->forget([
+             'comment_editing',
+             'comment_creating',
+             'note_editing,',
+             'volume',
+             'chapter',
+             'testament_array',
+             ]);
          
          return redirect(route('notes.index'));
      }
@@ -219,12 +232,12 @@ class NoteController extends Controller
       public function edit(Note $note, Tag $tag, Request $request)
       {
           // sessionに編集中のデータがない場合の処理
-          if (!session()->has('editing')) {
+          if (!session()->has('note_editing')) {
               // 編集するノートのtestamentsをsessionに保存する
               // 特定の$noteに関連付けられたtestamentsからvolume_idとchapterの一意な値を抽出
               // それらの組み合わせごとに一致するtestamentsのidをセッションに保存する
               $note_id = $note->id;
-              session(['editing' => $note_id]); // sessionに編集しているnoteのidを保存
+              session(['note_editing' => $note_id]); // sessionに編集しているnoteのidを保存
               
               $note_volumes = $note->testaments->pluck('volume_id')->toArray(); // $noteの持つtestamentsのvolume_idを配列で取得
               $note_chapters = $note->testaments->pluck('chapter')->toArray(); // $noteの持つtestamentsのchapterを配列で取得
@@ -361,7 +374,14 @@ class NoteController extends Controller
           $unique_key_to_delete = array_unique($keys_to_delete); // 重複するキーを削除
           // 配列に保存されたセッションキーを一括で削除
           session()->forget($unique_key_to_delete);
-          session()->forget(['editing', 'volume', 'chapter', 'testament_array']);
+          session()->forget([
+             'comment_editing',
+             'comment_creating',
+             'note_editing,',
+             'volume',
+             'chapter',
+             'testament_array',
+             ]);
           
           return redirect('/notes/' . $note->id);
       }

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -31,13 +31,12 @@ class NoteController extends Controller
                 }
             }
             
-            $unique_keys_to_delete = array_merge($keys_to_delete); // 重複するキーを削除
+            $unique_keys_to_delete = array_unique($keys_to_delete); // 重複するキーを削除
             // 配列に保存されたセッションキーを一括で削除
             session()->forget($unique_keys_to_delete);
-            session()->forget(['volume', 'chapter', 'testament_array']);
+            session()->forget(['editing', 'volume', 'chapter', 'testament_array']);
         }
         
-        $notes = $note->get();
         return view('notes.index')->with(['notes' => $note->get()]);
     }
     
@@ -206,7 +205,7 @@ class NoteController extends Controller
              }
          }
         
-         $unique_key_to_delete = array_merge($keys_to_delete); // 重複するキーを削除
+         $unique_key_to_delete = array_unique($keys_to_delete); // 重複するキーを削除
          // 配列に保存されたセッションキーを一括で削除
          session()->forget($unique_key_to_delete);
          session()->forget(['volume', 'chapter', 'testament_array']);
@@ -359,7 +358,7 @@ class NoteController extends Controller
               }
           }
         
-          $unique_key_to_delete = array_merge($keys_to_delete); // 重複するキーを削除
+          $unique_key_to_delete = array_unique($keys_to_delete); // 重複するキーを削除
           // 配列に保存されたセッションキーを一括で削除
           session()->forget($unique_key_to_delete);
           session()->forget(['editing', 'volume', 'chapter', 'testament_array']);

--- a/app/Http/Controllers/TestamentController.php
+++ b/app/Http/Controllers/TestamentController.php
@@ -53,9 +53,17 @@ class TestamentController extends Controller
         //インスタンスのvolume_id未満のvolume_idの中で最新のchapterを取得                         
         $previous_volume_latest_chapter = $testament->getPreviousVolumeLatestChapter($volume);
         
-        // noteの編集中であれば、noteのidを取得
-        if(session()->has('editing')) {
-            $note_id = session('editing', []);
+        // ノートまたはコメントの作成・編集中であれば、noteのidを取得
+        if(session()->has('note_editing')) {
+            $edit_note_id = session('note_editing', []);
+        }
+        
+        if (session()->has('comment_creating')) {
+            $comment_create_note_id = session('comment_creating', []);
+        }
+        
+        if (session()->has('comment_editing')) {
+            $comment_edit_ids = session('comment_editing', []);
         }
         
         return view('testaments.show')->with([
@@ -67,7 +75,9 @@ class TestamentController extends Controller
             'latest_chapter' => $latest_chapter, 
             'earliest_chapter' => $earliest_chapter,
             'previous_volume_latest_chapter' => $previous_volume_latest_chapter,
-            'note_id' => $note_id ?? null,
+            'note_id' => $edit_note_id ?? null,
+            'comment_create_note_id' => $comment_create_note_id ?? null,
+            'comment_edit_ids' => $comment_edit_ids ?? null,
             ]);
     }
 }

--- a/app/Http/Controllers/TestamentController.php
+++ b/app/Http/Controllers/TestamentController.php
@@ -41,7 +41,7 @@ class TestamentController extends Controller
         
         $chapter_set = $contents->first();
         
-        $selected_testaments = session('ids_' . $volume . '_' . $chapter, []); //Sessionからすでに選ばれた配列を取得
+        $selected_testaments = session('testament_array', []); //Sessionからすでに選ばれた配列を取得
         $testament_id = collect($selected_testaments); // Collectionに変換
         
         // 最小のchapterを取得
@@ -53,6 +53,11 @@ class TestamentController extends Controller
         //インスタンスのvolume_id未満のvolume_idの中で最新のchapterを取得                         
         $previous_volume_latest_chapter = $testament->getPreviousVolumeLatestChapter($volume);
         
+        // noteの編集中であれば、noteのidを取得
+        if(session()->has('editing')) {
+            $note_id = session('editing', []);
+        }
+        
         return view('testaments.show')->with([
             'volume' => $volume,
             'chapter' => $chapter,
@@ -61,6 +66,8 @@ class TestamentController extends Controller
             'testament_id' => $testament_id,
             'latest_chapter' => $latest_chapter, 
             'earliest_chapter' => $earliest_chapter,
-            'previous_volume_latest_chapter' => $previous_volume_latest_chapter]);
+            'previous_volume_latest_chapter' => $previous_volume_latest_chapter,
+            'note_id' => $note_id ?? null,
+            ]);
     }
 }

--- a/resources/views/notes/comments/edit.blade.php
+++ b/resources/views/notes/comments/edit.blade.php
@@ -12,15 +12,20 @@
             <input type="hidden" name="new_comment[note_id]" value="{{ $note_id }}">
             <input type="text" name="new_comment[text]" placeholder="ここに入力" value="{{ $comment->text }}">
             <p class="title__error" style="color:red">{{ $errors->first('new_comment.text') }}</p>
-            <p>聖句を追加</p>
-            @foreach ($testaments as $testament)
-                <lavel>
-                    <input type="checkbox" value={{ $testament->id }} name="testaments_array[]" {{ $testament_id->contains($testament->id) ? 'checked' : '' }}>
-                        {{ $testament->text }}
-                </lavel>
+            <div class="testaments">
+                @foreach ($testaments as $testament)
+                    <input type="hidden" name="testaments_array[]" value="{{ $testament->id }}">
+                    <p>{{ $testament->text }}</p>
+                @endforeach
+                @if (count($testaments) === 0 or !$last_selected_testament)
+                <a href="/testaments">聖句を追加</a>
+                @else
+                <a href="/testaments/volume{{ $last_selected_testament->volume->id }}/chapter{{ $last_selected_testament->chapter }}">聖句を追加</a>
+                @endif
                 <br>
-            @endforeach
+            </div>
             <input type="submit" value="保存する"/>
+            <a href="/notes/{{ $note_id }}/comments?cancel_comment_take=true">変更をキャンセル</a>
         </form>
         <div class="footer">
             <a href="/notes/{{ $note_id }}/comments">戻る</a>

--- a/resources/views/notes/comments/index.blade.php
+++ b/resources/views/notes/comments/index.blade.php
@@ -41,16 +41,21 @@
                             <input type="hidden" name="new_comment[note_id]" value="{{ $note_id }}">
                             <input type="text" name="new_comment[text]" placeholder="ここに入力" value="{{ old('new_comment.text') }}">
                             <p class="title__error" style="color:red">{{ $errors->first('new_comment.text') }}</p>
-                            <p>聖句を追加</p>
-                            @foreach ($comment_testaments as $comment_testament)
-                                <lavel>
-                                    <input type="checkbox" value={{ $comment_testament->id }} name="testaments_array[]" {{ in_array($comment_testament->id, old('testaments_array', [])) ? 'checked' : '' }}>
-                                        {{ $comment_testament->text }}
-                                </lavel>
+                            <div class="testaments">
+                                @foreach ($testaments as $testament)
+                                    <input type="hidden" name="testaments_array[]" value="{{ $testament->id }}">
+                                    <p>{{ $testament->text }}</p>
+                                @endforeach
+                                @if (count($testaments) === 0 or !$last_selected_testament)
+                                <a href="/testaments">聖句を追加</a>
+                                @else
+                                <a href="/testaments/volume{{ $last_selected_testament->volume->id }}/chapter{{ $last_selected_testament->chapter }}">聖句を追加</a>
+                                @endif
                                 <br>
-                            @endforeach
+                            </div>
                             <input type="submit" value="投稿"/>
                         </form>
+                        <a href="/notes/{{ $note_id }}/comments?cancel_comment_take=true">キャンセル</a>
                     </div>
                 </div>
             </div>

--- a/resources/views/notes/create.blade.php
+++ b/resources/views/notes/create.blade.php
@@ -59,7 +59,7 @@
                                 <p class="image__error" style="color:red">{{ $errors->first('image') }}</p>
                             </div>
                             <input type="submit" value="保存する"/>
-                            <a href="/notes?cancel_notetake=true">キャンセル</a>
+                            <a href="/notes?cancel_note_take=true">キャンセル</a>
                         </form>
                     </div>
                 </div>

--- a/resources/views/notes/edit.blade.php
+++ b/resources/views/notes/edit.blade.php
@@ -17,15 +17,17 @@
                 非公開ノート
             </label>
             <br>
-            <div class="testament">
-                <h2>聖句</h2>
+           <div class="testaments">
                 @foreach ($testaments as $testament)
-                    <lavel>
-                        <input type="checkbox" value={{ $testament->id }} name="testaments_array[]" {{ $testament_id->contains($testament->id) ? 'checked' : '' }}>
-                            {{ $testament->text }}
-                    </lavel>
-                    <br>
+                    <input type="hidden" name="testaments_array[]" value="{{ $testament->id }}">
+                    <p>{{ $testament->text }}</p>
                 @endforeach
+                @if (count($testaments) === 0 or !$last_selected_testament)
+                <a href="/testaments">聖句を追加</a>
+                @else
+                <a href="/testaments/volume{{ $last_selected_testament->volume->id }}/chapter{{ $last_selected_testament->chapter }}">聖句を追加</a>
+                @endif
+                <br>
             </div>
             <div class="title">
                 <h2>タイトル</h2>

--- a/resources/views/notes/edit.blade.php
+++ b/resources/views/notes/edit.blade.php
@@ -50,7 +50,7 @@
                 @endforeach
             </div>
             <input type="submit" value="保存する"/>
-            <a href="/notes?cancel_notetake=true">キャンセル</a>
+            <a href="/notes?cancel_note_take=true">変更をキャンセル</a>
         </form>
         <div class="footer">
             <a href="{{ route('notes.index') }}">戻る</a>

--- a/resources/views/notes/edit.blade.php
+++ b/resources/views/notes/edit.blade.php
@@ -50,6 +50,7 @@
                 @endforeach
             </div>
             <input type="submit" value="保存する"/>
+            <a href="/notes?cancel_notetake=true">キャンセル</a>
         </form>
         <div class="footer">
             <a href="{{ route('notes.index') }}">戻る</a>

--- a/resources/views/notes/show.blade.php
+++ b/resources/views/notes/show.blade.php
@@ -66,8 +66,5 @@
                 </div>
             </div>
         </div>
-        <!-- デバックステップ -->
-        {{ dump($testament->chapter) }}
-        {{ dump($note) }}
     </body>
 </x-app-layout>

--- a/resources/views/testaments/show.blade.php
+++ b/resources/views/testaments/show.blade.php
@@ -8,12 +8,12 @@
             <div class="py-12">
                 <a href="/testaments">Home</a> > <a href="/testaments/volume{{ $volume }}">Volume {{ $volume }}</a> > <span>Chapter {{ $chapter }}</span>
                 <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                    <a href="#" id="sendData">ノートを作成する</a>
+                    <a href="#" id="sendData">選択した聖句からノートを作成する</a>
                     <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                         <div class="p-6 text-gray-900">
                             <h2>{{ $chapter_set->volume->title }}: 第{{ $chapter_set->chapter }}章</h2>
                             @foreach ($testaments as $testament)
-                                <input type="checkbox" value={{ $testament->id }} name="testaments_array[]">
+                                <input type="checkbox" value={{ $testament->id }} name="ids[]" {{ $testament_id->contains($testament->id) ? 'checked' : '' }}>
                                 <small>{{ $testament->section }}</small> {{ $testament->text }}<br>
                             @endforeach
                         </div>
@@ -53,7 +53,7 @@
             e.preventDefault(); // デフォルトのリンク挙動を無効化
         
             // 選択されたチェックボックスの値を収集
-            var selectedTestaments = document.querySelectorAll('input[name="testaments_array[]"]:checked');
+            var selectedTestaments = document.querySelectorAll('input[name="ids[]"]:checked');
             var values = [];
             selectedTestaments.forEach(function(testament) {
                 values.push(testament.value);
@@ -62,7 +62,7 @@
             // チェックボックスが1つ以上選択されている場合
             if (values.length > 0) {
                 // クエリパラメータを作成
-                var queryString = 'testaments_array[]=' + values.join('&testaments_array[]=');
+                var queryString = 'ids[]=' + values.join('&ids[]=');
         
                 // 判定したいnote_idがあるかどうかをチェック
                 @if(isset($note_id))

--- a/resources/views/testaments/show.blade.php
+++ b/resources/views/testaments/show.blade.php
@@ -65,9 +65,16 @@
                 var queryString = 'ids[]=' + values.join('&ids[]=');
         
                 // 判定したいnote_idがあるかどうかをチェック
-                @if(isset($note_id))
-                    var note_id = {{ $note_id }};
+                @if (isset($edit_note_id))
+                    var note_id = {{ $edit_note_id }};
                     var url = '/notes/' + note_id + '/edit?' + queryString;
+                @elseif (isset($comment_create_note_id))
+                    var note_id = {{ $comment_create_note_id }};
+                    var url = '/notes/' + note_id + '/comments?' + queryString;
+                @elseif (isset($comment_edit_ids))
+                    var note_id = {{ $comment_edit_ids[0] }};
+                    var comment_id = {{ $comment_edit_ids[1] }};
+                    var url = '/notes/' + note_id + '/comments/' + comment_id + '/edit?' + queryString;
                 @else
                     var url = '/notes/create?' + queryString;
                 @endif

--- a/resources/views/testaments/show.blade.php
+++ b/resources/views/testaments/show.blade.php
@@ -8,12 +8,12 @@
             <div class="py-12">
                 <a href="/testaments">Home</a> > <a href="/testaments/volume{{ $volume }}">Volume {{ $volume }}</a> > <span>Chapter {{ $chapter }}</span>
                 <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                    <a href="#" id="sendData">選択した聖句からノートを作成する</a>
+                    <a href="#" id="sendData">ノートを作成する</a>
                     <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                         <div class="p-6 text-gray-900">
                             <h2>{{ $chapter_set->volume->title }}: 第{{ $chapter_set->chapter }}章</h2>
                             @foreach ($testaments as $testament)
-                                <input type="checkbox" value={{ $testament->id }} name="ids[]" {{ $testament_id->contains($testament->id) ? 'checked' : '' }}>
+                                <input type="checkbox" value={{ $testament->id }} name="testaments_array[]">
                                 <small>{{ $testament->section }}</small> {{ $testament->text }}<br>
                             @endforeach
                         </div>
@@ -53,19 +53,24 @@
             e.preventDefault(); // デフォルトのリンク挙動を無効化
         
             // 選択されたチェックボックスの値を収集
-            var selectedTestaments = document.querySelectorAll('input[name="ids[]"]:checked');
+            var selectedTestaments = document.querySelectorAll('input[name="testaments_array[]"]:checked');
             var values = [];
-            selectedTestaments.forEach(function(id) {
-                values.push(id.value);
+            selectedTestaments.forEach(function(testament) {
+                values.push(testament.value);
             });
         
             // チェックボックスが1つ以上選択されている場合
             if (values.length > 0) {
                 // クエリパラメータを作成
-                var queryString = 'ids[]=' + values.join('&ids[]=');
-                
-                // GETリクエストを送信するURLを作成
-                var url = '/notes/create?' + queryString;
+                var queryString = 'testaments_array[]=' + values.join('&testaments_array[]=');
+        
+                // 判定したいnote_idがあるかどうかをチェック
+                @if(isset($note_id))
+                    var note_id = {{ $note_id }};
+                    var url = '/notes/' + note_id + '/edit?' + queryString;
+                @else
+                    var url = '/notes/create?' + queryString;
+                @endif
         
                 // GETリクエストを実行
                 window.location.href = url;

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,6 +58,7 @@ Route::post('/notes', [NoteController::class, 'store'])
 // ノート編集処理
 Route::get('/notes/{note}/edit', [NoteController::class, 'edit'])
     ->name('notes.edit');
+// ノート更新処理
 Route::put('/notes/{note}', [NoteController::class, 'update'])
     ->name('notes.update');
     
@@ -67,9 +68,13 @@ Route::get('/notes/{note}/comments', [CommentController::class, 'index']);
 //コメント保存処理
 Route::post('/notes/{note}/comments', [CommentController::class, 'store']);
 
+// コメント編集処理
 Route::get('/notes/{note}/comments/{comment}/edit', [CommentController::class, 'edit']);
 
+// コメント削除処理
 Route::delete('/notes/{note}/comments/{comment}', [CommentController::class, 'delete']);
+
+// コメント更新処理
 Route::put('/notes/{note}/comments/{comment}', [CommentController::class, 'update']);
     
 // ノート削除処理

--- a/routes/web.php
+++ b/routes/web.php
@@ -79,7 +79,9 @@ Route::delete('/notes/{note}', [NoteController::class, 'delete'])
 Route::get('/tags', [TagController::class, 'index'])->name('tags.index');
 // タグ保存処理
 Route::post('/tags', [TagController::class, 'store']);
-
+// タグ削除処理
 Route::delete('/tags/{tag}', [TagController::class, 'delete']);
+// タグ編集処理
 Route::get('/tags/{tag}/edit', [TagController::class, 'edit']);
+// タグ更新処理
 Route::put('/tags/{tag}', [TagController::class, 'update']);


### PR DESCRIPTION
## 概要
ノートの編集・更新とコメントのCRUDに、#34 で実装したsessionへのデータの保持・削除のメカニズムを実装した。
## 変更点
- 編集処理
  - #34 のメカニズムを編集データにも使うために、処理を追加
    - それぞれのコントローラのeditメソッドに、編集したいデータのコレクションから聖句を取り出すメカニズムを追加した。
      - インスタンスから取り出した`testaments`の`volume_id`、`chapter`をsessionの`volume`、`chapter`に保存
      - 保存したsessionのキーを使って`volume`,`chapter`ごとのキーを生成し、値を保存する
      - testament_arrayにすべての`id`を格納して、sessionの`testament_array`に保存
- コメントの作成・保存・編集・更新にもこれらの処理を適用した
- リンクをクリックするときや、それぞれの操作（Commentの作成・編集、Noteの作成・編集）を区別するため、sessionにユニークなキーを保存する。
## やり残したこと
- FatControllerがすぎるので、Traitなどを使って処理をまとめたい

