### PR TITLE
Fix #36 bug fix and pagination

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -34,7 +34,7 @@ class CommentController extends Controller
             session()->forget([
                  'comment_editing',
                  'comment_creating',
-                 'note_editing,',
+                 'note_editing',
                  'volume',
                  'chapter',
                  'testament_array',
@@ -93,7 +93,7 @@ class CommentController extends Controller
         $testaments = Testament::whereIn('id', session('testament_array', []))->get();
         
         // 特定のnote_idに関連するコメントを取得するクエリを実行
-        $comments = $comment::where('note_id', $note)->get();
+        $comments = Comment::where('note_id', $note)->orderBy('updated_at', 'asc')->paginate(5);
         
         return view('notes.comments.index')->with([
             'note_id' => $note,
@@ -136,7 +136,7 @@ class CommentController extends Controller
          session()->forget([
              'comment_editing',
              'comment_creating',
-             'note_editing,',
+             'note_editing',
              'volume',
              'chapter',
              'testament_array',
@@ -295,7 +295,7 @@ class CommentController extends Controller
           session()->forget([
              'comment_editing',
              'comment_creating',
-             'note_editing,',
+             'note_editing',
              'volume',
              'chapter',
              'testament_array',

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -32,16 +32,13 @@ class CommentController extends Controller
             // 配列に保存されたセッションキーを一括で削除
             session()->forget($unique_keys_to_delete);
             session()->forget([
-             'comment_creating',
-             'note_editing,',
-             'volume',
-             'chapter',
-             'testament_array',
+                 'comment_editing',
+                 'comment_creating',
+                 'note_editing,',
+                 'volume',
+                 'chapter',
+                 'testament_array',
              ]);
-        }
-        
-        if (!session()->has('comment_creating')) {
-            session(['comment_creating' => $note]);
         }
         
         // クエリパラメータidsが送られた場合の処理
@@ -124,7 +121,7 @@ class CommentController extends Controller
          $volumes = session('volume', []);
          $chapters = session('chapter', []);
         
-         $key_to_delete = []; // 削除するセッションキーの配列
+         $keys_to_delete = []; // 削除するセッションキーの配列
         
          foreach ($volumes as $volume) {
              foreach ($chapters as $chapter) {
@@ -283,7 +280,7 @@ class CommentController extends Controller
           $volumes = session('volume', []);
           $chapters = session('chapter', []);
         
-          $key_to_delete = []; // 削除するセッションキーの配列
+          $keys_to_delete = []; // 削除するセッションキーの配列
         
           foreach ($volumes as $volume) {
               foreach ($chapters as $chapter) {

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -35,15 +35,16 @@ class NoteController extends Controller
             // 配列に保存されたセッションキーを一括で削除
             session()->forget($unique_keys_to_delete);
             session()->forget([
-             'comment_creating',
-             'note_editing,',
-             'volume',
-             'chapter',
-             'testament_array',
+                 'comment_editing',
+                 'comment_creating',
+                 'note_editing,',
+                 'volume',
+                 'chapter',
+                 'testament_array',
              ]);
         }
         
-        return view('notes.index')->with(['notes' => $note->get()]);
+        return view('notes.index')->with(['notes' => $note->getPaginateByLimit()]);
     }
     
     /**
@@ -202,7 +203,7 @@ class NoteController extends Controller
          $volumes = session('volume', []);
          $chapters = session('chapter', []);
         
-         $key_to_delete = []; // 削除するセッションキーの配列
+         $keys_to_delete = []; // 削除するセッションキーの配列
         
          foreach ($volumes as $volume) {
              foreach ($chapters as $chapter) {
@@ -362,7 +363,7 @@ class NoteController extends Controller
           $volumes = session('volume', []);
           $chapters = session('chapter', []);
         
-          $key_to_delete = []; // 削除するセッションキーの配列
+          $keys_to_delete = []; // 削除するセッションキーの配列
         
           foreach ($volumes as $volume) {
               foreach ($chapters as $chapter) {
@@ -377,7 +378,7 @@ class NoteController extends Controller
           session()->forget([
              'comment_editing',
              'comment_creating',
-             'note_editing,',
+             'note_editing',
              'volume',
              'chapter',
              'testament_array',

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -15,7 +15,7 @@ class NoteController extends Controller
     /**
      * ノート一覧画面
      */
-    public function index(Request $request, Note $note)
+    public function index(Request $request, Note $note, Tag $tag)
     {
         if ($request->has('cancel_note_take')) {
             // sessionからvolumeキー、chapterキーの値を取得
@@ -44,7 +44,13 @@ class NoteController extends Controller
              ]);
         }
         
-        return view('notes.index')->with(['notes' => $note->getPaginateByLimit()]);
+        if ($request->has('tag')) {
+            $tag_id = $request->query('tag');
+            $tag_notes = $note->getByTag($tag_id);
+            return view('notes.index')->with(['notes' => $tag_notes, 'tags' => $tag->get()]);
+        } else {
+            return view('notes.index')->with(['notes' => $note->getPaginateByLimit(), 'tags' => $tag->get()]);
+        }
     }
     
     /**
@@ -182,7 +188,7 @@ class NoteController extends Controller
      public function store(Note $note, NoteRequest $request)
      {
          $input_note = $request['note'];
-         $input_testaments = $request->testament_array;
+         $input_testaments = $request->testaments_array;
          $input_tags = $request->tags_array;
          
          if ($request->file('image')) { //画像ファイルが送られたときだけ処理が実行される

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -37,7 +37,7 @@ class NoteController extends Controller
             session()->forget([
                  'comment_editing',
                  'comment_creating',
-                 'note_editing,',
+                 'note_editing',
                  'volume',
                  'chapter',
                  'testament_array',
@@ -218,7 +218,7 @@ class NoteController extends Controller
          session()->forget([
              'comment_editing',
              'comment_creating',
-             'note_editing,',
+             'note_editing',
              'volume',
              'chapter',
              'testament_array',

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -9,7 +9,7 @@ class TagController extends Controller
 {
     public function index(Tag $tag)
     {
-        return view('tags.index')->with(['tags' => $tag->get()]);
+        return view('tags.index')->with(['tags' => $tag->getPaginateByLimit()]);
     }
     
     public function store(Request $request, Tag $tag)

--- a/app/Http/Controllers/TestamentController.php
+++ b/app/Http/Controllers/TestamentController.php
@@ -11,8 +11,15 @@ class TestamentController extends Controller
     /**
      * 聖書一覧画面
      */
-     public function index(Volume $volume)
+     public function index(Volume $volume, Request $request)
      {
+         if ($request->has('comment_create')) {
+             $note_id = $request->query('comment_create');
+             if (!session()->has('comment_creating')) {
+                session(['comment_creating' => $note_id]);
+            }
+         }
+         
          return view('testaments.index')->with(['volumes' => $volume->get()]);
      }
      
@@ -66,6 +73,9 @@ class TestamentController extends Controller
             $comment_edit_ids = session('comment_editing', []);
         }
         
+        // セッション内のすべてのデータを取得する（デバック)
+        $all_session_data = session()->all();
+        
         return view('testaments.show')->with([
             'volume' => $volume,
             'chapter' => $chapter,
@@ -75,9 +85,10 @@ class TestamentController extends Controller
             'latest_chapter' => $latest_chapter, 
             'earliest_chapter' => $earliest_chapter,
             'previous_volume_latest_chapter' => $previous_volume_latest_chapter,
-            'note_id' => $edit_note_id ?? null,
+            'edit_note_id' => $edit_note_id ?? null,
             'comment_create_note_id' => $comment_create_note_id ?? null,
             'comment_edit_ids' => $comment_edit_ids ?? null,
+            'all_session_data' => $all_session_data,
             ]);
     }
 }

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -40,4 +40,10 @@ class Comment extends Model
       {
          return $this->belongsToMany(Testament::class); 
       }
+      
+      public function getPaginateByLimit(int $limit_count = 2)
+      {
+          // updated_atで降順に並べたあと、limitで件数制限をかける
+          return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
+      }
 }

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -51,14 +51,17 @@ class Note extends Model
           return $this->belongsTo(User::class);
       }
       
-      public function recordSectionInfoByVolumeAndChapter()
-      {
-          //section番号を取得するメソッドを書く
-      }
-      
       public function getPaginateByLimit(int $limit_count = 4)
       {
           // updated_atで降順に並べたあと、limitで件数制限をかける
           return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
       }
+      
+      public function getByTag($tag_id, int $limit_count = 2)
+      {
+          return $this::whereHas('tags', function ($query) use ($tag_id) {
+              $query->where('tags.id', $tag_id);
+          })->orderBy('updated_at', 'DESC')->paginate($limit_count);
+      }
+
 }

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -55,4 +55,10 @@ class Note extends Model
       {
           //section番号を取得するメソッドを書く
       }
+      
+      public function getPaginateByLimit(int $limit_count = 4)
+      {
+          // updated_atで降順に並べたあと、limitで件数制限をかける
+          return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
+      }
 }

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -24,6 +24,14 @@ class Tag extends Model
          return $this->belongsToMany(Testament::class);
      }
      
+    /**
+     * Noteモデルとのリレーションシップ
+     */
+     public function notes()
+     {
+         return $this->belongsToMany(Note::class);
+     } 
+     
      /**
       * Questionモデルとのリレーションシップ
       */

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -39,4 +39,10 @@ class Tag extends Model
        {
           return $this->belongsTo(Color::class);
        }
+       
+       public function getPaginateByLimit(int $limit_count = 4)
+       {
+          // updated_atで降順に並べたあと、limitで件数制限をかける
+          return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
+       }
 }

--- a/resources/views/notes/comments/index.blade.php
+++ b/resources/views/notes/comments/index.blade.php
@@ -28,6 +28,9 @@
                     </div>
                 </div>
             @endforeach
+            <div class='paginate'>
+                {{ $comments->links() }}
+            </div>
         </div>
         <div class="new_comment">
             <br>

--- a/resources/views/notes/comments/index.blade.php
+++ b/resources/views/notes/comments/index.blade.php
@@ -47,7 +47,7 @@
                                     <p>{{ $testament->text }}</p>
                                 @endforeach
                                 @if (count($testaments) === 0 or !$last_selected_testament)
-                                <a href="/testaments">聖句を追加</a>
+                                <a href="/testaments?comment_create={{ $note_id }}">聖句を追加</a>
                                 @else
                                 <a href="/testaments/volume{{ $last_selected_testament->volume->id }}/chapter{{ $last_selected_testament->chapter }}">聖句を追加</a>
                                 @endif

--- a/resources/views/notes/index.blade.php
+++ b/resources/views/notes/index.blade.php
@@ -17,9 +17,6 @@
                             @endif
                             <p>{{ $note->created_at }}</p>
                             <a href="/notes/{{ $note->id }}">{{ $note->title }}<a>
-                            <div class="note_text">
-                                <p>{{ $note->text }}</p>
-                            </div>
                             <div class="note_tag">
                                 @foreach ($note->tags as $tag)
                                     <p>{{ $tag->tag }}</p>
@@ -40,8 +37,9 @@
                 </div>
                 <br>
             @endforeach
-            <!-- デバックステップ -->
-            {{ dump($notes) }}
+            <div class='paginate'>
+                {{ $notes->links() }}
+            </div>
         </div>
         <script>
             function deleteNote(id) {

--- a/resources/views/notes/index.blade.php
+++ b/resources/views/notes/index.blade.php
@@ -5,6 +5,13 @@
     
     <body>
         <div class="notes">
+            <div class="tags">
+                @foreach ($tags as $tag)
+                    <span>
+                        <a href="/notes?tag={{ $tag->id }}">{{ $tag->tag }}</a>
+                    </span>
+                @endforeach
+            </div>
             <a href="{{ route('notes.create') }}">ノートを書く</a>
             @foreach($notes as $note)
                 <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">

--- a/resources/views/notes/show.blade.php
+++ b/resources/views/notes/show.blade.php
@@ -66,5 +66,6 @@
                 </div>
             </div>
         </div>
+        {{ dump($note) }}
     </body>
 </x-app-layout>

--- a/resources/views/tags/index.blade.php
+++ b/resources/views/tags/index.blade.php
@@ -36,6 +36,9 @@
                         </div>
                     </div>
                 @endforeach
+                <div class='paginate'>
+                    {{ $tags->links() }}
+                </div>
             </div>
         </div>
     </body>

--- a/resources/views/testaments/index.blade.php
+++ b/resources/views/testaments/index.blade.php
@@ -14,7 +14,6 @@
                                 <a href="/testaments/volume{{ $volume->id }}">{{ $volume->title }}</a>
                                 <br>
                             @endforeach
-                            {{ dump($volumes)}}
                         </div>
                     </div>
                 </div>

--- a/resources/views/testaments/show.blade.php
+++ b/resources/views/testaments/show.blade.php
@@ -12,10 +12,15 @@
                     <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                         <div class="p-6 text-gray-900">
                             <h2>{{ $chapter_set->volume->title }}: 第{{ $chapter_set->chapter }}章</h2>
-                            @foreach ($testaments as $testament)
-                                <input type="checkbox" value={{ $testament->id }} name="ids[]" {{ $testament_id->contains($testament->id) ? 'checked' : '' }}>
-                                <small>{{ $testament->section }}</small> {{ $testament->text }}<br>
-                            @endforeach
+                                @foreach ($testaments as $testament)
+                                     <label>
+                                        <input type="checkbox" value={{ $testament->id }} name="ids[]" {{ $testament_id->contains($testament->id) ? 'checked' : '' }}>
+                                            <span>
+                                                <small>{{ $testament->section }}</small> {{ $testament->text }}
+                                            </span>
+                                     <label>
+                                @endforeach
+                            </label>
                         </div>
                     </div>
                 </div>
@@ -39,13 +44,8 @@
             @else
                 <a href="/testaments/volume{{ $volume }}/chapter{{ $testament->chapter + 1 }}">→</a>
             @endif
-            <br>
         </div>
-            {{ $volume }} {{ $chapter}}
-            {{ $latest_chapter }}
-            {{ $earliest_chapter }}
-            {{ $previous_volume_latest_chapter }}
-            {{ dump($testaments) }}
+        {{ var_dump($all_session_data) }}
     </body>
     <script>
         // aタグをクリックした際の処理

--- a/resources/views/testaments/volume.blade.php
+++ b/resources/views/testaments/volume.blade.php
@@ -13,7 +13,6 @@
                             @foreach ($chapters as $chapter)
                                 <a href="/testaments/volume{{ $volume }}/chapter{{ $chapter }}">Chapter {{ $chapter }}</a>
                             @endforeach
-                            {{ dump($chapters)}}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## 概要
- #22 の処理のバグを修正
- ノート一覧画面とタグ一覧画面にページネーションを実装
- ノート一覧画面でノートをタグごとに表示できるようにした
## 変更点
- バグの修正
  - sessionのメカニズムで変数名の誤りによるエラーがあったため修正
- ページネーション
  - `Note`モデルと`Tag`モデルにページネーション処理`getPaginateByLimit`を追加。updated_atで降順に並べたあと、limitで件数制限をかける。
- ノートをタグごとに表示
  - ノート一覧画面にタグ一覧を表示。特定のタグをクリックすると、同様のページにクエリパラメータtag={tagのid}を含んだURLが送信される
  - ノート一覧画面表示のコントローラメソッドに処理を追加。クエリパラメータtag={tagのid}を含んでいたとき、そのidを持つノートを引数にモデルのメソッドを実行する。得られた$noteをviewファイルに渡す。
  - `Note`モデルに`getByTag`を追加。`notes`テーブルから、`Note`とn:nのリレーションシップを定義している`tags`の特定カラムの値を含むレコードを取得する。
## 課題点
- `getByTag`に使用している`whereHas`メソッドは、MySQLのパフォーマンスに悪影響なので、レコードの取り出し方を変更する必要がある。
## 参考
(https://qiita.com/hisash/items/40532808e61ed3210a6a)