### PR TITLE
#42 Access restrictions, #44 friend requests, #38 UI adjustments

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Models\Comment;
 use App\Models\Testament;
 use App\Http\Requests\CommentRequest;
+use Illuminate\Support\Facades\Auth;
 
 class CommentController extends Controller
 {
@@ -100,12 +101,19 @@ class CommentController extends Controller
         // 特定のnote_idに関連するコメントを取得するクエリを実行
         $comments = Comment::where('note_id', $note)->orderBy('updated_at', 'asc')->paginate(5);
         
+        // セッション内のすべてのデータを取得する（デバック)
+        $all_session_data = session()->all();
+        
+        $user_id = Auth::id();
+        
         return view('notes.comments.index')->with([
             'note_id' => $note,
             'comments' => $comments,
             'testaments' => $testaments,
             'testaments_by_volume_and_chapter' => $testaments_by_volume_and_chapter,
             'last_selected_testament' => $last_selected_testament ?? null,
+            'all_session_data' => $all_session_data,
+            'user_id' => $user_id,
             ]);
     }
      

--- a/app/Http/Controllers/ConnectionController.php
+++ b/app/Http/Controllers/ConnectionController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Connection;
+use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 
 class ConnectionController extends Controller
@@ -11,18 +12,36 @@ class ConnectionController extends Controller
     public function index(Connection $connection)
     {
         $user_id = Auth::id();
-        $friends = $connection::where(function ($query) use ($user_id) {
-            $query->orWhere('follow_id', $user_id)
-                  ->orWhere('followed_id', $user_id)
-                  ->where('approval', 1);
-        })->get();
+        
+        // 友達のidを取得
+        $friend_ids = $connection::where(function ($query) use ($user_id) {
+            $query->where('approval', 1)
+                  ->where(function ($query) use ($user_id) {
+                      $query->orWhere('follow_id', $user_id)
+                            ->orWhere('followed_id', $user_id);
+                  });
+        })->get()->flatMap(function ($record) use ($user_id) {
+            return [$record->follow_id, $record->followed_id];
+        })->reject(function ($friend_id) use ($user_id) {
+            return $friend_id == $user_id;
+        })->unique()->values()->toArray();
+
+        
+        // 友達でないユーザーのレコードを取得
+        $users = User::whereNotIn('id', $friend_ids)
+             ->where('id', '!=', $user_id)
+             ->paginate(10);
+
+        // ユーザーの友達のレコードを取得
+        $friends = User::whereIn('id', $friend_ids)->paginate(10);
         
         $followers = $connection::where(function ($query) use ($user_id) {
             $query->where('followed_id', $user_id)
                   ->where('approval', 0);
-        })->get();
+        })->paginate(10);
         
         return view('connections.index')->with([
+            'users' => $users,
             'friends' => $friends,
             'followers' => $followers,
             ]);
@@ -40,10 +59,36 @@ class ConnectionController extends Controller
     
     public function unFriend(Connection $connection, Request $request)
     {
-        $input_id = $request->input('connections_id');
-        $target_connection = $connection->find($input_id);
+        $input_id = $request->input('friend_id');
+        $user_id = Auth::id();
+        
+        // 対象のconnectionを取得
+        $target_connection = $connection::where(function ($query) use ($input_id, $user_id) {
+            $query->where('approval', 1)
+                  ->where(function ($query) use ($input_id, $user_id) {
+                      $query->orwhere('follow_id', $input_id)
+                            ->orWhere('followed_id', $input_id);
+                  })
+                  ->where(function ($query) use ($input_id, $user_id) {
+                      $query->orwhere('follow_id', $user_id)
+                            ->orWhere('followed_id', $user_id);
+                  });
+        });
         
         $target_connection->update(['approval' => 0]);
+        
+        return redirect('/connections');
+    }
+    
+    public function followUser(Connection $connection, Request $request)
+    {
+        $input_id = $request->input('user_id');
+        
+        $new_connection = ['follow_id' => $request->user()->id];
+        $new_connection += ['followed_id' => $input_id];
+        $new_connection += ['approval' => 0];
+        
+        $connection->fill($new_connection)->save();
         
         return redirect('/connections');
     }

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -334,6 +334,12 @@ class NoteController extends Controller
           $input_note = $request['note'];
           $input_testaments = $request->testaments_array;
           $input_tags = $request->tags_array;
+          
+          if ($request->file('image')) { //画像ファイルが送られたときだけ処理が実行される
+            //cloudinaryへ画像を送信し、画像のURLを$image_urlに代入
+            $image_url = Cloudinary::upload($request->file('image')->getRealPath())->getSecurePath();
+            $input_note += ['image_url' => $image_url];
+         }
          
           $input_note += ['user_id' => $request->user()->id]; // user():requestを送信したユーザーの情報を取得するRequestメソッド
           $note->fill($input_note)->save();

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -4,12 +4,15 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Tag;
+use Illuminate\Support\Facades\Auth;
 
 class TagController extends Controller
 {
     public function index(Tag $tag)
     {
-        return view('tags.index')->with(['tags' => $tag->getPaginateByLimit()]);
+        $user_id = Auth::id();
+        
+        return view('tags.index')->with(['tags' => $tag->getPaginateByLimit($user_id), 'user_id' => $user_id]);
     }
     
     public function store(Request $request, Tag $tag)

--- a/app/Http/Controllers/TestamentController.php
+++ b/app/Http/Controllers/TestamentController.php
@@ -30,7 +30,9 @@ class TestamentController extends Controller
     {
         $chapters = $testament->where('volume_id', $volume)->groupBy('chapter')->pluck('chapter');
         
-        return view('testaments.volume')->with(['volume' => $volume, 'chapters' => $chapters]);
+        $volume_title = Volume::where('id', $volume)->first();
+        
+        return view('testaments.volume')->with(['volume' => $volume, 'chapters' => $chapters, 'volume_title' => $volume_title]);
     }
      
     /**

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use App\Models\Connection;
 
 class Tag extends Model
 {
@@ -48,9 +49,28 @@ class Tag extends Model
           return $this->belongsTo(Color::class);
        }
        
-       public function getPaginateByLimit(int $limit_count = 10)
+       public function getPaginateByLimit(int $user_id, int $limit_count = 10)
        {
+          // ログインユーザーのタグと友達のタグを取得するクエリを構築
+          $query = $this->query()->where('user_id', $user_id);
+          
+          // 友達のidを取得する
+          $friend_ids = Connection::where(function ($query) use ($user_id) {
+              $query->where('approval', 1)
+                    ->where(function ($query) use ($user_id) {
+                        $query->orWhere('follow_id', $user_id)
+                              ->orWhere('followed_id', $user_id);
+                    });
+          })->get()->flatMap(function ($record) use ($user_id) {
+              return [$record->follow_id, $record->followed_id];
+          })->reject(function ($friend_id) use ($user_id) {
+              return $friend_id == $user_id;
+          })->unique()->values()->toArray();
+          
+          // 友達のタグも含める
+          $query->orWhereIn('user_id', $friend_ids);
+          
           // updated_atで降順に並べたあと、limitで件数制限をかける
-          return $this->orderBy('updated_at', 'DESC')->paginate($limit_count);
+          return $query->orderBy('updated_at', 'DESC')->paginate($limit_count);
        }
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -40,7 +40,7 @@
             @endif
 
             <x-primary-button class="ml-3">
-                {{ __('Log in') }}
+                {{ __('ログイン') }}
             </x-primary-button>
         </div>
     </form>

--- a/resources/views/connections/index.blade.php
+++ b/resources/views/connections/index.blade.php
@@ -3,11 +3,11 @@
         <div class="py-12">
             <p>友達一覧</p>
             @foreach ($friends as $friend)
-                <form action="/connections" method="POST">
+                <form action="/connections/unfriend" method="POST">
                     @csrf
                     @method('PUT')
-                    <input type="hidden" name="connections_id" value="{{ $friend->id }}">
-                    {{ $friend->followedBy->name }}
+                    <input type="hidden" name="friend_id" value="{{ $friend->id }}">
+                    {{ $friend->name }}
                     <div class="inline-flex items-center px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
                         <input type="submit" value="友達登録を解除"/>
                     </div>
@@ -15,12 +15,23 @@
             @endforeach
             <p>以下のユーザーから友達リクエストが来ています</p>
             @foreach ($followers as $follower)
-                <form action="/connections" method="POST">
+                <form action="/connections/approval" method="POST">
                     @csrf
                     <input type="hidden" name="connections_id" value="{{ $follower->id }}">
                     {{ $follower->followedBy->name }}
                     <div class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
                         <input type="submit" value="友達リクエストを承認"/>
+                    </div>
+                </form>
+            @endforeach
+            <p>ユーザー一覧</p>
+            @foreach ($users as $user)
+                <form action="/connections/follow" method="POST">
+                    @csrf
+                    <input type="hidden" name="user_id" value="{{ $user->id }}">
+                    {{ $user->name }}
+                    <div class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                        <input type="submit" value="友達リクエストを送信する"/>
                     </div>
                 </form>
             @endforeach

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,10 +1,4 @@
 <x-app-layout>
-    <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Dashboard') }}
-        </h2>
-    </x-slot>
-
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -4,6 +4,13 @@
             <a class="text-lg hover:text-gray-300" href="{{ route('dashboard') }}">
                 {{ config('app.name') }}
             </a>
+            <div class="flex-grow"></div>
+            <div class="user_name">
+                @if (Auth::check())
+                <p>ユーザー名: {{ Auth::user()->name }}</p>
+                @endif
+            </div>
+            <div class="mx-2"></div>
             <div>
                 @if (Auth::check())
                 <x-dropdown>

--- a/resources/views/notes/comments/index.blade.php
+++ b/resources/views/notes/comments/index.blade.php
@@ -3,62 +3,72 @@
         <div class="py-12">
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                 <div class="p-6 text-gray-900">
-                    <div class="footer">
-                        <a href="/notes/{{ $note_id }}">戻る</a>
+                    <div class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                        <a href="/notes/{{ $note_id }}">ノートに戻る</a>
                     </div>
                     <div class="comments">
-                        <div class="flex flex-col">
-                            @foreach ($comments as $comment)
-                                @if (Auth::user()->id === $comment->user->id)
-                                <div class="flex justify-end">
-                                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                                        <p>{{ $comment->user->name }}</p>
-                                        <p>{{ $comment->created_at }}</p>
-                                        <p>{{ $comment->text }}</p>
-                                        @foreach ($comment->testaments as $testament)
-                                            <p>{{ $testament->text }}</p>
-                                        @endforeach
-                                        <a href="/notes/{{ $note_id }}/comments/{{ $comment->id }}/edit">このコメントを編集する</a>
-                                        <form action="/notes/{{ $note_id }}/comments/{{ $comment->id }}" id="form_{{ $comment->id }}" method="post">
-                                            @csrf
-                                            @method('DELETE')
-                                            <button type="button" onclick="deleteComment({{ $comment->id }})">このコメントを削除する</button>
-                                        </form>
+                        @foreach ($comments as $comment)
+                        <div class="p-3">
+                            <div class="bg-gray-100 overflow-hidden shadow-sm sm:rounded-lg overflow-visible">
+                                <div class="flex items-center justify-between">
+                                    <div><p>{{ $comment->user->name }}・{{ $comment->created_at }}</p></div>
+                                    <div>
+                                        @if ($comment->user_id === $user_id)
+                                        <x-dropdown align="light">
+                                            <x-slot name="trigger" class="relative z-60">
+                                                <button>
+                                                    <svg class="h-6 w-6 text-gray-500"  fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"/>
+                                                    </svg>
+                                                </button>
+                                            </x-slot>
+                                            <x-slot name="content">
+                                                <x-dropdown-link href="/notes/{{ $note_id }}/comments/{{ $comment->id }}/edit">編集する</x-dropdown-link>
+                                                <x-dropdown-link>
+                                                    <form action="/notes/{{ $note_id }}/comments/{{ $comment->id }}" id="form_{{ $comment->id }}" method="post">
+                                                        @csrf
+                                                        @method('DELETE')
+                                                        <button type="button" onclick="deleteComment({{ $comment->id }})">このコメントを削除する</button>
+                                                    </form>
+                                                </x-dropdown-link>
+                                            </x-slot>
+                                        </x-dropdown>
+                                        @endif
                                     </div>
                                 </div>
-                                @else
-                                <div class="flex justify-start">
-                                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                                        <p>{{ $comment->user->name }}</p>
-                                        <p>{{ $comment->created_at }}</p>
-                                        <p>{{ $comment->text }}</p>
-                                        @foreach ($comment->testaments as $testament)
-                                            <p>{{ $testament->text }}</p>
-                                        @endforeach
-                                        <a href="/notes/{{ $note_id }}/comments/{{ $comment->id }}/edit">このコメントを編集する</a>
-                                        <form action="/notes/{{ $note_id }}/comments/{{ $comment->id }}" id="form_{{ $comment->id }}" method="post">
-                                            @csrf
-                                            @method('DELETE')
-                                            <button type="button" onclick="deleteComment({{ $comment->id }})">このコメントを削除する</button>
-                                        </form>
-                                    </div>
-                                </div>
-                                @endif
-                            @endforeach
+                                <p>{{ $comment->text }}</p>
+                                @foreach ($comment->testaments as $testament)
+                                    <p>{{ $testament->text }}</p>
+                                @endforeach
+                            </div>
                         </div>
+                        @endforeach
                         <div class='paginate'>
                             {{ $comments->links() }}
                         </div>
                     </div>
+                    <br>
                     <div class="new_comment">
-                        <br>
-                        <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                            <p>新しいコメントを追加</p>
-                            <form action="/notes/{{ $note_id }}/comments" method="POST">
-                                @csrf
+                        <form action="/notes/{{ $note_id }}/comments" method="POST">
+                        @csrf
+                        <div class="flex items-center justify-between">
+                            <div><p>新しいコメントを追加</p></div>
+                            <div class="flex-grow"></div>
+                            <div class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                                <input type="submit" value="投稿"/>
+                            </div>
+                            <div class="mx-2"></div>
+                            <div class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-500 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                                <div class="footer">
+                                    <a href="/notes/{{ $note_id }}/comments?cancel_comment_take=true">キャンセル</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="p-3">
+                            <div class="flex flex-col">
                                 <!-- hiddenフィールドとしてnote_idを追加 -->
                                 <input type="hidden" name="new_comment[note_id]" value="{{ $note_id }}">
-                                <input type="text" name="new_comment[text]" placeholder="ここに入力" value="{{ old('new_comment.text') }}">
+                                <input class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block w-5/6" type="text" name="new_comment[text]" placeholder="ここに入力" value="{{ old('new_comment.text') }}">
                                 <p class="title__error" style="color:red">{{ $errors->first('new_comment.text') }}</p>
                                 <div class="testaments">
                                     @foreach ($testaments as $testament)
@@ -84,13 +94,13 @@
                                     @endif
                                     <br>
                                 </div>
-                                <input type="submit" value="投稿"/>
-                            </form>
-                            <a href="/notes/{{ $note_id }}/comments?cancel_comment_take=true">キャンセル</a>
+                            </div>
                         </div>
+                        </form> 
                     </div>
                 </div>
             </div>
+
         </div>
         <script>
             function deleteComment(id) {

--- a/resources/views/notes/edit.blade.php
+++ b/resources/views/notes/edit.blade.php
@@ -15,7 +15,7 @@
                                 <input type="submit" value="変更を保存する"/>
                             </div>
                             <div class="inline-flex items-center px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-500 active:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition ease-in-out duration-150">
-                                <a href="/notes?cancel_note_take=true">キャンセル</a>
+                                <a href="/notes?cancel_note_take=true">変更をキャンセル</a>
                             </div>
                         </div>
                     </div>

--- a/resources/views/notes/edit.blade.php
+++ b/resources/views/notes/edit.blade.php
@@ -2,7 +2,7 @@
     <body>
         <div class="py-12">
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                <form action="/notes/{{ $note->id }}" method="POST">
+                <form action="/notes/{{ $note->id }}" method="POST" enctype="multipart/form-data">
                     @csrf
                     @method('PUT')
                     <div class="flex items-center justify-between">
@@ -12,7 +12,7 @@
                         </select>
                         <div>
                             <div class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
-                                <input type="submit" value="保存する"/>
+                                <input type="submit" value="変更を保存する"/>
                             </div>
                             <div class="inline-flex items-center px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-500 active:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition ease-in-out duration-150">
                                 <a href="/notes?cancel_note_take=true">キャンセル</a>
@@ -60,6 +60,15 @@
                                 </option>
                             @endforeach
                         </select>
+                    </div>
+                    <div class="image">
+                        @if ($note->image_url)
+                        <div class="image">
+                            <img src="{{ $note->image_url }}" alt="画像が読み込めません。"/>
+                        </div>
+                        @endif
+                        <input class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block" type="file" name="image">
+                        <p class="image__error" style="color:red">{{ $errors->first('image') }}</p>
                     </div>
                 </form>
             </div>

--- a/resources/views/notes/index.blade.php
+++ b/resources/views/notes/index.blade.php
@@ -85,6 +85,8 @@
                                             </button>
                                         </x-slot>
                                         <x-slot name="content">
+                                            <x-dropdown-link href="/notes/{{ $note->id }}/comments">コメントする</x-dropdown-link>
+                                            @if ($note->user_id === $user_id)
                                             <x-dropdown-link href="/notes/{{ $note->id }}/edit">編集する</x-dropdown-link>
                                             <x-dropdown-link>
                                                 <form action="/notes/{{ $note->id }}" id="form_{{ $note->id }}" method="post">
@@ -93,10 +95,11 @@
                                                     <button type="button" onclick="deleteNote({{ $note->id }})">このノートを削除する</button>
                                                 </form>
                                             </x-dropdown-link>
+                                            @endif
                                         </x-slot>
                                     </x-dropdown>
                                 </div>
-                                <p>{{ $note->created_at }}</p>
+                                <p>{{ $note->user->name }}・{{ $note->created_at }}</p>
                                 <a href="/notes/{{ $note->id }}">{{ $note->title }}<a>
                                 @if($note->image_url)
                                 <div class="image">

--- a/resources/views/notes/show.blade.php
+++ b/resources/views/notes/show.blade.php
@@ -29,19 +29,36 @@
                         </div>
                         <div class="flex-grow"></div>
                         <div class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
-                            <div class="edit">
-                                <a href="/notes/{{ $note->id }}/edit">編集する</a>
-                            </div>
-                        </div>
-                        <div class="mx-2"></div>
-                        <div class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
                             <div class="footer">
                                 <a href="{{ route('notes.index') }}">ノート一覧に戻る</a>
                             </div>
                         </div>
+                        <div class="mx-2"></div>
+                        <x-dropdown align="light">
+                            <x-slot name="trigger" class="relative z-60">
+                                <button>
+                                    <svg class="h-6 w-6 text-gray-500"  fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"/>
+                                    </svg>
+                                </button>
+                            </x-slot>
+                            <x-slot name="content">
+                                <x-dropdown-link href="/notes/{{ $note->id }}/comments">コメントする</x-dropdown-link>
+                                @if ($note->user_id === $user_id)
+                                <x-dropdown-link href="/notes/{{ $note->id }}/edit">編集する</x-dropdown-link>
+                                <x-dropdown-link>
+                                    <form action="/notes/{{ $note->id }}" id="form_{{ $note->id }}" method="post">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="button" onclick="deleteNote({{ $note->id }})">このノートを削除する</button>
+                                    </form>
+                                </x-dropdown-link>
+                                @endif
+                            </x-slot>
+                        </x-dropdown>
                     </div>
                     <div class="note">
-                        <p>{{ $note->created_at }}</p>
+                        <p>{{ $note->user->name }}・{{ $note->created_at }}</p>
                         @if ($note->public === 1)
                             <h1>公開ノート</h1>
                         @else
@@ -69,17 +86,18 @@
                         </div>
                         @endif
                     </div>
-                    <div class="comments">
-                        @foreach ($note->comments as $comment)
-                            <p>{{ $comment->text }}</p>
-                            @foreach ($comment->testaments as $testament)
-                                <p>{{ $testament->text }}</p>
-                            @endforeach
-                        @endforeach
-                        <a href='/notes/{{ $note->id }}/comments'>コメント一覧を表示する</a>
-                    </div>
+                    <a href='/notes/{{ $note->id }}/comments'>コメント一覧を表示する</a>
                 </div>
             </div>
         </div>
     </body>
+    <script>
+        function deleteNote(id) {
+            'use strict'
+            
+            if (confirm('削除すると復元できません。本当に削除しますか？')) {
+                document.getElementById(`form_${id}`).submit();
+            }
+        }
+    </script>
 </x-app-layout>

--- a/resources/views/tags/index.blade.php
+++ b/resources/views/tags/index.blade.php
@@ -11,14 +11,15 @@
                     </div>
                 </div>
             </form>
-            <div class="grid sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-3">
+            <div class="grid sm:grid-cols-6 md:grid-cols-6 lg:grid-cols-6">
                 @foreach ($tags as $tag)
                     <div class="p-3">
                         <div class="bg-gray-100 overflow-hidden shadow-sm sm:rounded-lg overflow-visible">
                             <div class="flex justify-between py-1">
                                 <div class="tags">
-                                    <p>{{ $tag->tag }}</p>
+                                    <a href="/notes?tag={{ $tag->id }}">{{ $tag->tag }}</a>
                                 </div>
+                                @if ($tag->user_id === $user_id)
                                 <x-dropdown align="light">
                                     <x-slot name="trigger" class="relative z-60">
                                         <button>
@@ -38,6 +39,7 @@
                                         </x-dropdown-link>
                                     </x-slot>
                                 </x-dropdown>
+                                @endif
                             </div>
                         </div>
                     </div>

--- a/resources/views/testaments/index.blade.php
+++ b/resources/views/testaments/index.blade.php
@@ -13,10 +13,17 @@
                 </div>
                 <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div class="p-6 text-gray-900">
-                        @foreach ($volumes as $volume)
-                            <a href="/testaments/volume{{ $volume->id }}">{{ $volume->title }}</a>
-                            <br>
-                        @endforeach
+                        <div class="grid sm:grid-cols-4 md:grid-cols-4 lg:grid-cols-4">
+                            @foreach ($volumes as $volume)
+                                <div class="p-3">
+                                    <div class="bg-gray-100 overflow-hidden shadow-sm sm:rounded-lg overflow-visible">
+                                        <div class="text-center">
+                                            <a href="/testaments/volume{{ $volume->id }}">{{ $volume->title }}</a>
+                                        </div>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
                     </div>
                 </div>
             </div>

--- a/resources/views/testaments/show.blade.php
+++ b/resources/views/testaments/show.blade.php
@@ -9,12 +9,12 @@
                             <svg onclick="location.href='/testaments'" xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 576 512" class="cursor-pointer hover:fill-blue-500 transition-colors duration-300" fill="#4b5563"><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M575.8 255.5c0 18-15 32.1-32 32.1h-32l.7 160.2c0 2.7-.2 5.4-.5 8.1V472c0 22.1-17.9 40-40 40H456c-1.1 0-2.2 0-3.3-.1c-1.4 .1-2.8 .1-4.2 .1H416 392c-22.1 0-40-17.9-40-40V448 384c0-17.7-14.3-32-32-32H256c-17.7 0-32 14.3-32 32v64 24c0 22.1-17.9 40-40 40H160 128.1c-1.5 0-3-.1-4.5-.2c-1.2 .1-2.4 .2-3.6 .2H104c-22.1 0-40-17.9-40-40V360c0-.9 0-1.9 .1-2.8V287.6H32c-18 0-32-14-32-32.1c0-9 3-17 10-24L266.4 8c7-7 15-8 22-8s15 2 21 7L564.8 231.5c8 7 12 15 11 24z"/></svg>        <span class="mx-2">/</span>
                           </li>
                           <li class="flex items-center">
-                            <a href="/testaments/volume{{ $volume }}" class="text-gray-600 hover:text-blue-500 transition-colors duration-300">Volume {{ $volume }}</a>
+                            <a href="/testaments/volume{{ $volume }}" class="text-gray-600 hover:text-blue-500 transition-colors duration-300">{{ $chapter_set->volume->title }}</a>
                             <span class="mx-2">/</span>
                           </li>
                           <li class="flex items-center">
                             <span class="text-gray-600 hover:text-blue-500 transition-colors duration-300">
-                                <a href="/testaments/volume{{ $volume }}/chapter{{ $chapter }}">Chapter {{ $chapter }}</a>
+                                <a href="/testaments/volume{{ $volume }}/chapter{{ $chapter }}">第{{ $chapter }}章</a>
                             </span>
                           </li>
                         </ol>
@@ -23,9 +23,9 @@
                         <a href="#" id="sendData">選択した聖句からノートを作成する</a>
                     </div>
                 </div>
-                <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="max-w-5xl mx-auto sm:px-6 lg:px-8">
                     <div class="p-6 text-gray-900">
-                        <div class="mx-auto max-w-2xl lg:mx-0">
+                        <div class="mx-auto max-w-5xl lg:mx-0">
                           <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">{{ $chapter_set->volume->title }}: 第{{ $chapter_set->chapter }}章</h2>
                           <div class="mt-2 text-lg leading-8 text-gray-600">
                               @foreach ($testaments as $testament)

--- a/resources/views/testaments/show.blade.php
+++ b/resources/views/testaments/show.blade.php
@@ -14,7 +14,7 @@
                           </li>
                           <li class="flex items-center">
                             <span class="text-gray-600 hover:text-blue-500 transition-colors duration-300">
-                                <a href="/testaments/volume{{ $volume }}/chapter{{ $chapter }}">第{{ $chapter }}章</a>
+                                <a href="/testaments/volume{{ $volume }}/chapter{{ $chapter }}">第{{ $chapter }}{{ $volume === '19' ? '篇' : '章' }}</a>
                             </span>
                           </li>
                         </ol>
@@ -26,7 +26,9 @@
                 <div class="max-w-5xl mx-auto sm:px-6 lg:px-8">
                     <div class="p-6 text-gray-900">
                         <div class="mx-auto max-w-5xl lg:mx-0">
-                          <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">{{ $chapter_set->volume->title }}: 第{{ $chapter_set->chapter }}章</h2>
+                          <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+                              {{ $chapter_set->volume->title }}: 第{{ $chapter_set->chapter }}{{ $volume === '19' ? '篇' : '章' }}
+                          </h2>
                           <div class="mt-2 text-lg leading-8 text-gray-600">
                               @foreach ($testaments as $testament)
                                  <label>
@@ -39,14 +41,13 @@
                           </div>
                         </div>  
                     </div>
-                    
                 </div>
             </div>
         </div>
         <!--現時点のchapterの値に応じて、前後のページに移動するメカニズム -->
         <div class="pagination">
             <div class="fixed bottom-2 left-0 right-0 p-4 flex justify-between items-center">
-                @if ($volume == 1 and $chapter == 1)
+                @if ($volume == '1' and $chapter == '1')
                     <p></p>
                 @elseif ($earliest_chapter->chapter_id === $testament->chapter)
                     <a href="/testaments/volume{{ $volume - 1 }}/chapter{{ $previous_volume_latest_chapter->chapter_id }}">
@@ -60,7 +61,7 @@
                     </a>
                 @endif
                 
-                @if ($volume === 66 and $testament->chapter === 22)
+                @if ($volume === '66' and $chapter === '22')
                     <p></p>
                 @elseif ($latest_chapter->chapter_id === $testament->chapter)
                     <a href="/testaments/volume{{ $volume + 1 }}/chapter1">

--- a/resources/views/testaments/volume.blade.php
+++ b/resources/views/testaments/volume.blade.php
@@ -17,9 +17,17 @@
                 </div>
                 <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div class="p-6 text-gray-900">
-                        @foreach ($chapters as $chapter)
-                            <a href="/testaments/volume{{ $volume }}/chapter{{ $chapter }}">第{{ $chapter }}章</a>
-                        @endforeach
+                        <div class="grid sm:grid-cols-6 md:grid-cols-6 lg:grid-cols-6">
+                            @foreach ($chapters as $chapter)
+                                <div class="p-3">
+                                    <div class="bg-gray-100 overflow-hidden shadow-sm sm:rounded-lg overflow-visible">
+                                        <div class="text-center">
+                                            <a href="/testaments/volume{{ $volume }}/chapter{{ $chapter }}">{{ $chapter }}</a>
+                                        </div>
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
                     </div>
                 </div>
             </div>

--- a/resources/views/testaments/volume.blade.php
+++ b/resources/views/testaments/volume.blade.php
@@ -9,7 +9,7 @@
                             <svg onclick="location.href='/testaments'" xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 576 512" class="cursor-pointer hover:fill-blue-500 transition-colors duration-300" fill="#4b5563"><!--! Font Awesome Free 6.4.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d="M575.8 255.5c0 18-15 32.1-32 32.1h-32l.7 160.2c0 2.7-.2 5.4-.5 8.1V472c0 22.1-17.9 40-40 40H456c-1.1 0-2.2 0-3.3-.1c-1.4 .1-2.8 .1-4.2 .1H416 392c-22.1 0-40-17.9-40-40V448 384c0-17.7-14.3-32-32-32H256c-17.7 0-32 14.3-32 32v64 24c0 22.1-17.9 40-40 40H160 128.1c-1.5 0-3-.1-4.5-.2c-1.2 .1-2.4 .2-3.6 .2H104c-22.1 0-40-17.9-40-40V360c0-.9 0-1.9 .1-2.8V287.6H32c-18 0-32-14-32-32.1c0-9 3-17 10-24L266.4 8c7-7 15-8 22-8s15 2 21 7L564.8 231.5c8 7 12 15 11 24z"/></svg>        <span class="mx-2">/</span>
                           </li>
                           <li class="flex items-center">
-                            <a href="/testaments/volume{{ $volume }}" class="text-gray-600 hover:text-blue-500 transition-colors duration-300">Volume {{ $volume }}</a>
+                            <a href="/testaments/volume{{ $volume }}" class="text-gray-600 hover:text-blue-500 transition-colors duration-300">{{ $volume_title->title }}</a>
                             <span class="mx-2">/</span>
                           </li>
                         </ol>
@@ -18,7 +18,7 @@
                 <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div class="p-6 text-gray-900">
                         @foreach ($chapters as $chapter)
-                            <a href="/testaments/volume{{ $volume }}/chapter{{ $chapter }}">Chapter {{ $chapter }}</a>
+                            <a href="/testaments/volume{{ $volume }}/chapter{{ $chapter }}">第{{ $chapter }}章</a>
                         @endforeach
                     </div>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,22 +53,23 @@ Route::controller(NoteController::class)->middleware('auth')->group(function () 
 
 Route::controller(CommentController::class)->middleware('auth')->group(function () {
     Route::get('/notes/{note}/comments', 'index')->name('comments.index');
-    Route::post('/notes/{note}/comments', 'store')->name('store');
-    Route::get('/notes/{note}/comments/{comment}/edit', 'edit')->name('edit');
-    Route::put('/notes/{note}/comments/{comment}', 'update')->name('update');
-    Route::delete('/notes/{note}/comments/{comment}', 'delete')->name('delete');
+    Route::post('/notes/{note}/comments', 'store')->name('comments.store');
+    Route::get('/notes/{note}/comments/{comment}/edit', 'edit')->name('comments.edit');
+    Route::put('/notes/{note}/comments/{comment}', 'update')->name('comments.update');
+    Route::delete('/notes/{note}/comments/{comment}', 'delete')->name('comments.delete');
 });
 
 Route::controller(TagController::class)->middleware('auth')->group(function () {
     Route::get('/tags', 'index')->name('tags.index');
-    Route::post('/tags', 'store')->name('store');
-    Route::delete('/tags/{tag}', 'delete')->name('delete');
-    Route::get('/tags/{tag}/edit', 'edit')->name('edit');
-    Route::put('/tags/{tag}', 'update')->name('update');
+    Route::post('/tags', 'store')->name('tags.store');
+    Route::delete('/tags/{tag}', 'delete')->name('tags.delete');
+    Route::get('/tags/{tag}/edit', 'edit')->name('tags.edit');
+    Route::put('/tags/{tag}', 'update')->name('tags.update');
 });
 
 Route::controller(ConnectionController::class)->middleware('auth')->group(function () {
     Route::get('/connections', 'index')->name('connections.index');
-    Route::post('/connections', 'approvalUserRequest')->name('approvalUserRequest');
-    Route::put('/connections', 'unFriend')->name('unFriend');
+    Route::post('/connections/approval', 'approvalUserRequest')->name('approvalUserRequest');
+    Route::put('/connections/unfriend', 'unFriend')->name('unFriend');
+    Route::post('/connections/follow', 'followUser')->name('followUser');
 });


### PR DESCRIPTION
## 概要
- ノート、コメント、タグのCRUDについてアクセス制限をかけた
- ユーザーに対して友達リクエストをする処理を追加した
- UIに変更を加えた
## 変更点
- CRUDのアクセス制限
    - ログインユーザーとその友達のレコードのみを取得するため、Noteモデル・Commentコントローラのメソッドに以下の処理を追加
      - ログインユーザーのidを用いて友達のidを取得
      - ログインユーザーのid及び友達のidを用いてレコードを取得
    - ログインユーザーのidと一致しないノートについて、ノート一覧画面・詳細画面で、編集・削除ができないようbladeファイルにif構文を追加
- 友達リクエスト
  - Connectionモデルに以下の処理を追加
    - indexメソッドで、Userモデルから友達ではないユーザーのレコードを取得してbladeファイルに渡す
    - followUserメソッドを追加。リクエストで受け取った友達ではないゆーざーのidとログインユーザーのidを使って、connectionテーブルに未承認のconnectionレコードを保存
- UIの変更
  - 聖書のvolumeとchapter一覧画面が見づらかったので、gridを使って画面全体に均等に表示するようにした
## その他
- ノートの写真を編集時に変更できるようにした
- Connectionコントローラの友達のidを取得する処理が間違っていため変更し、その処理を他のメソッドに適用した