### PR TITLE
#51 Fixed and added validation rules, fixed scripture insertion bug, #44 determined sent

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -103,9 +103,9 @@ class CommentController extends Controller
 
         // volume,chapterごとにtestamentsをグルーピング
         foreach ($comments as $comment) {
-            $testaments = $comment->testaments;
+            $comments_testaments = $comment->testaments;
         
-            $grouped_testaments = $testaments->groupBy('volume_id')->map(function ($testaments) {
+            $grouped_testaments = $comments_testaments->groupBy('volume_id')->map(function ($testaments) {
                 return $testaments->groupBy('chapter');
             });
         

--- a/app/Http/Controllers/ConnectionController.php
+++ b/app/Http/Controllers/ConnectionController.php
@@ -26,14 +26,18 @@ class ConnectionController extends Controller
             return $friend_id == $user_id;
         })->unique()->values()->toArray();
 
+        // ユーザーの友達のレコードを取得
+        $friends = User::whereIn('id', $friend_ids)->paginate(10);
+        
+        $follows = $connection::where(function ($query) use ($user_id) {
+            $query->where('follow_id', $user_id)
+                  ->where('approval', 0);
+        })->pluck('followed_id');
         
         // 友達でないユーザーのレコードを取得
         $users = User::whereNotIn('id', $friend_ids)
-             ->where('id', '!=', $user_id)
-             ->paginate(10);
-
-        // ユーザーの友達のレコードを取得
-        $friends = User::whereIn('id', $friend_ids)->paginate(10);
+            ->where('id', '!=', $user_id)
+            ->paginate(20);
         
         $followers = $connection::where(function ($query) use ($user_id) {
             $query->where('followed_id', $user_id)
@@ -43,6 +47,7 @@ class ConnectionController extends Controller
         return view('connections.index')->with([
             'users' => $users,
             'friends' => $friends,
+            'follows' => $follows,
             'followers' => $followers,
             ]);
     }

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Http\Requests\TagRequest;
 use App\Models\Tag;
 use Illuminate\Support\Facades\Auth;
 
@@ -15,7 +16,7 @@ class TagController extends Controller
         return view('tags.index')->with(['tags' => $tag->getPaginateByLimit($user_id), 'user_id' => $user_id]);
     }
     
-    public function store(Request $request, Tag $tag)
+    public function store(TagRequest $request, Tag $tag)
     {
         $input_tag = $request['tag'];
         $input_tag += ['user_id' => $request->user()->id];
@@ -30,7 +31,7 @@ class TagController extends Controller
         return view('tags.edit')->with(['tag' => $tag]);
     }
     
-    public function update(Request $request, Tag $tag)
+    public function update(TagRequest $request, Tag $tag)
     {
         $input_tag = $request['tag'];
         $input_tag += ['user_id' => $request->user()->id];

--- a/app/Http/Requests/NoteRequest.php
+++ b/app/Http/Requests/NoteRequest.php
@@ -24,9 +24,9 @@ class NoteRequest extends FormRequest
     public function rules()
     {
         return [
-            'note.title' => 'required',
+            'note.title' => 'required|max:100',
             'note.text' => 'required',
-            'image' => 'max:2097152',
+            'image' => 'max:2048',
         ];
     }
 }

--- a/app/Http/Requests/TagRequest.php
+++ b/app/Http/Requests/TagRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TagRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'tag.tag' => 'required|string|max:20',
+        ];
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -32,11 +32,10 @@ class DatabaseSeeder extends Seeder
         // 外部キー制約の有効化
         Schema::enableForeignKeyConstraints();
         
-        $this->call([
-            VolumeTableSeeder::class,
-            TestamentTableSeeder::class,
-        ]);
-        
+        //$this->call([
+        //    VolumeTableSeeder::class,
+        //    TestamentTableSeeder::class,
+        //]);
     }
     
     /**
@@ -46,11 +45,14 @@ class DatabaseSeeder extends Seeder
     {
         // テーブルのリスト
         $tables = [
-            'testaments',
-            'volumes',
             'notes',
+            'note_tag',
+            'note_testament',
             'comments',
+            'comment_testament',
             'tags',
+            'connections',
+            'users',
             ];
         
         // テーブルごとにtruncate

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -253,6 +253,11 @@ return [
         'updated_at' => '更新日',
         'username' => 'ユーザー名',
         'year' => '年',
+        'tag.tag' => 'タグ',
+        'new_comment.text' => 'コメント',
+        'note.title' => 'タイトル',
+        'note.text' => '本文',
+        'image' => '写真データ',
     ],
 
 ];

--- a/resources/views/connections/index.blade.php
+++ b/resources/views/connections/index.blade.php
@@ -3,6 +3,7 @@
         <div class="py-12">
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                 <div class="p-6 text-gray-900">
+                    @if (!empty($friends))
                     <p class="mb-2 text-2xl font-bold tracking-tight text-gray-900">友達一覧:</p>
                     @foreach ($friends as $friend)
                         <form action="/connections/unfriend" method="POST">
@@ -16,6 +17,10 @@
                         </form>
                         <div class="py-1"></div>
                     @endforeach
+                    @endif
+                    <div class='paginate'>
+                        {{ $friends->links() }}
+                    </div>
                     <br>
                     @if (!empty($followers))
                         <p class="mb-2 text-2xl font-bold tracking-tight text-gray-900">以下のユーザーから友達リクエストが来ています:</p>
@@ -31,9 +36,13 @@
                             <div class="py-1"></div>
                         @endforeach
                     @endif
+                    <div class='paginate'>
+                        {{ $followers->links() }}
+                    </div>
                     <br>
                     <p class="mb-2 text-2xl font-bold tracking-tight text-gray-900">ユーザー一覧:</p>
                     @foreach ($users as $user)
+                        @if (!$follows->contains($user->id))
                         <form action="/connections/follow" method="POST">
                             @csrf
                             <input type="hidden" name="user_id" value="{{ $user->id }}">
@@ -42,8 +51,17 @@
                                 <input type="submit" value="友達リクエストを送信する"/>
                             </div>
                         </form>
+                        @else
+                        {{ $user->name }}
+                        <div class="inline-flex items-center px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                            リクエスト送信済
+                        </div>
+                        @endif
                         <div class="py-1"></div>
                     @endforeach
+                    <div class='paginate'>
+                        {{ $users->links() }}
+                    </div>
                 </div>
             </div>
         </div>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -17,8 +17,8 @@
     <body class="font-sans text-gray-900 antialiased">
         <div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100">
             <div>
-                <a href="/">
-                    <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
+                <a class="text-lg hover:text-gray-300" href="/">
+                    {{ config('app.name') }}
                 </a>
             </div>
 

--- a/resources/views/notes/comments/index.blade.php
+++ b/resources/views/notes/comments/index.blade.php
@@ -47,17 +47,17 @@
                                     @if ($comment->grouped_testaments && count($comment->grouped_testaments) > 0)
                                         <blockquote class="p-4 my-4 border-s-4 border-gray-300 bg-gray-50">
                                             @foreach ($comment->grouped_testaments as $volume_id => $chapters)
-                                                @foreach ($chapters as $chapter => $testaments)
-                                                    @foreach ($testaments as $testament)
-                                                        <p class="italic font-medium leading-relaxed text-gray-900">{{ $testament->text }}</p>
+                                                @foreach ($chapters as $chapter => $sections)
+                                                    @foreach ($sections as $section)
+                                                        <p class="italic font-medium leading-relaxed text-gray-900">{{ $section->text }}</p>
                                                     @endforeach
                                                     <div class="h-3"></div>
                                                     @php
-                                                        $first_section = $testaments->first()->section;
-                                                        $last_section = $testaments->last()->section;
+                                                        $first_section = $sections->first()->section;
+                                                        $last_section = $sections->last()->section;
                                                         $section_to_display = $first_section === $last_section ? $first_section : "$first_section-$last_section";
                                                     @endphp
-                                                    <p>{{ $testaments->first()->volume->title }} {{ $chapter }}: {{ $section_to_display }}</p>
+                                                    <p>{{ $sections->first()->volume->title }} {{ $chapter }}: {{ $section_to_display }}</p>
                                                 @endforeach
                                                 @if (!$loop->last)
                                                     <br>
@@ -82,10 +82,10 @@
                             <div><p>新しいコメントを追加</p></div>
                             <div class="flex-grow"></div>
                             <div class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
-                                <input type="submit" value="投稿"/>
+                                <input type="submit" value="コメントを投稿"/>
                             </div>
                             <div class="mx-2"></div>
-                            <div class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-500 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                            <div class="inline-flex items-center px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-500 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
                                 <div class="footer">
                                     <a href="/notes/{{ $note_id }}/comments?cancel_comment_take=true">キャンセル</a>
                                 </div>

--- a/resources/views/notes/create.blade.php
+++ b/resources/views/notes/create.blade.php
@@ -2,82 +2,82 @@
     <body>
         <div class="py-12">
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-                    <div class="p-6 text-gray-900">
-                        <form action="/notes" method="POST" enctype="multipart/form-data">
-                            @csrf
-                            <div class="flex items-center justify-between">
-                                <select class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block" name="note[public]">
-                                    <option value="1" {{ $public_value == true ? 'selected' : '' }}>公開ノート</option>
-                                    <option value="0" {{ $public_value == false ? 'selected' : '' }}>非公開ノート</option>
-                                </select>
-                                <div>
-                                    <div class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
-                                        <input type="submit" value="保存する"/>
-                                    </div>
-                                    <div class="inline-flex items-center px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-500 active:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition ease-in-out duration-150">
-                                        <a href="/notes?cancel_note_take=true">キャンセル</a>
-                                    </div>
+                <div class="p-6 text-gray-900">
+                    <form action="/notes" method="POST" enctype="multipart/form-data">
+                        @csrf
+                        <div class="flex items-center justify-between">
+                            <select class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block" name="note[public]">
+                                <option value="1" {{ $public_value == true ? 'selected' : '' }}>公開ノート</option>
+                                <option value="0" {{ $public_value == false ? 'selected' : '' }}>非公開ノート</option>
+                            </select>
+                            <div>
+                                <div class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                                    <input type="submit" value="保存する"/>
+                                </div>
+                                <div class="inline-flex items-center px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-500 active:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                                    <a href="/notes?cancel_note_take=true">キャンセル</a>
                                 </div>
                             </div>
-                            <br>
-                            <div class="testaments">
-                                @foreach ($testaments as $testament)
-                                    <input type="hidden" name="testaments_array[]" value="{{ $testament->id }}">
-                                @endforeach
-                                @if ($testaments_by_volume_and_chapter && count($testaments_by_volume_and_chapter) > 0)
-                                <blockquote class="p-4 my-4 border-s-4 border-gray-300 bg-gray-50">
-                                    @foreach ($testaments_by_volume_and_chapter as $volume_id => $chapters)
-                                        @foreach ($chapters as $chapter => $testaments)
-                                            @foreach ($testaments as $testament)
-                                                <p class="italic font-medium leading-relaxed text-gray-900">{{ $testament->text }}</p>
-                                            @endforeach
-                                            <div class="h-3"></div>
-                                            @php
-                                                $first_section = $testaments->first()->section;
-                                                $last_section = $testaments->last()->section;
-                                                $section_to_display = $first_section === $last_section ? $first_section : "$first_section-$last_section";
-                                            @endphp
-                                            <p>{{ $testaments->first()->volume->title }} {{ $chapter }}: {{ $section_to_display }}</p>
+                        </div>
+                        <br>
+                        <div class="testaments">
+                            @foreach ($testaments as $testament)
+                                <input type="hidden" name="testaments_array[]" value="{{ $testament->id }}">
+                            @endforeach
+                            @if ($testaments_by_volume_and_chapter && count($testaments_by_volume_and_chapter) > 0)
+                            <blockquote class="p-4 my-4 border-s-4 border-gray-300 bg-gray-50">
+                                @foreach ($testaments_by_volume_and_chapter as $volume_id => $chapters)
+                                    @foreach ($chapters as $chapter => $testaments)
+                                        @foreach ($testaments as $testament)
+                                            <p class="italic font-medium leading-relaxed text-gray-900">{{ $testament->text }}</p>
                                         @endforeach
-                                        @if (!$loop->last)
-                                            <br>
-                                        @endif
+                                        <div class="h-3"></div>
+                                        @php
+                                            $first_section = $testaments->first()->section;
+                                            $last_section = $testaments->last()->section;
+                                            $section_to_display = $first_section === $last_section ? $first_section : "$first_section-$last_section";
+                                        @endphp
+                                        <p>{{ $testaments->first()->volume->title }} {{ $chapter }}: {{ $section_to_display }}</p>
                                     @endforeach
-                                </blockquote>
-                                @endif
-                                <span class="bg-gray-100 text-gray-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded">
-                                    @if (count($testaments) === 0 or !$last_selected_testament)
-                                    <a href="/testaments">聖句を追加</a>
-                                    @else
-                                    <a href="/testaments/volume{{ $last_selected_testament->volume->id }}/chapter{{ $last_selected_testament->chapter }}">聖句を追加</a>
+                                    @if (!$loop->last)
+                                        <br>
                                     @endif
-                                </span>
-                                <br>
-                            </div>
-                            <div class="title">
-                                <input class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block w-2/3" type="text" name="note[title]" placeholder="タイトル" value="{{ old('note.title')}}">
-                                <p class="title__error" style="color:red">{{ $errors->first('note.title') }}</p>
-                            </div>
-                            <div class="text">
-                                <textarea class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block w-full h-screen" name="note[text]" placeholder="ここにノートを入力">{{ old('note.text')}}</textarea>
-                                <p class="text__error" style="color:red">{{ $errors->first('note.text') }}</p>
-                            </div>
-                            
-                            <div class="tag">
-                                <select class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block" name="tags_array[]" multiple>
-                                    @foreach($tags as $tag)
-                                        <option value="{{ $tag->id }}" {{ in_array($tag->id, old('tags_array', [])) ? 'selected' : '' }}>
-                                            {{ $tag->tag }}
-                                        </option>
-                                    @endforeach
-                                </select>
-                            </div>
-                            <div class="image">
-                                <input class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block" type="file" name="image">
-                                <p class="image__error" style="color:red">{{ $errors->first('image') }}</p>
-                            </div>
-                        </form>
-                    </div>
+                                @endforeach
+                            </blockquote>
+                            @endif
+                            <span class="bg-gray-100 text-gray-800 text-sm font-medium me-2 px-2.5 py-0.5 rounded">
+                                @if (count($testaments) === 0 or !$last_selected_testament)
+                                <a href="/testaments">聖句を追加</a>
+                                @else
+                                <a href="/testaments/volume{{ $last_selected_testament->volume->id }}/chapter{{ $last_selected_testament->chapter }}">聖句を追加</a>
+                                @endif
+                            </span>
+                            <br>
+                        </div>
+                        <div class="title">
+                            <input class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block w-2/3" type="text" name="note[title]" placeholder="タイトル" value="{{ old('note.title')}}">
+                            <p class="title__error" style="color:red">{{ $errors->first('note.title') }}</p>
+                        </div>
+                        <div class="text">
+                            <textarea class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block w-full h-screen" name="note[text]" placeholder="ここにノートを入力">{{ old('note.text')}}</textarea>
+                            <p class="text__error" style="color:red">{{ $errors->first('note.text') }}</p>
+                        </div>
+                        
+                        <div class="tag">
+                            <select class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block" name="tags_array[]" multiple>
+                                @foreach($tags as $tag)
+                                    <option value="{{ $tag->id }}" {{ in_array($tag->id, old('tags_array', [])) ? 'selected' : '' }}>
+                                        {{ $tag->tag }}
+                                    </option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="image">
+                            <input class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block" type="file" name="image">
+                            <p class="image__error" style="color:red">{{ $errors->first('image') }}</p>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
     </body>

--- a/resources/views/notes/edit.blade.php
+++ b/resources/views/notes/edit.blade.php
@@ -73,9 +73,13 @@
                     </div>
                     <div class="image">
                         @if ($note->image_url)
-                        <div class="image">
-                            <img src="{{ $note->image_url }}" alt="画像が読み込めません。"/>
-                        </div>
+                        <p class="mb-2 text-2xl font-bold tracking-tight text-gray-900">現在登録されている写真:</p>
+                        <ul class="mt-3 gap-4 md:gap-6 xl:gap-8 w-1/2">
+                            <li class="group flex justify-center items-center bg-gray-100 overflow-hidden rounded-lg shadow-lg relative">
+                                <img src="{{ $note->image_url }}" class="object-contain object-center group-hover:scale-105 transition duration-200"/>
+                            </li>
+                        </ul>
+                        <div class="py-1"></div>
                         @endif
                         <input class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block" type="file" name="image">
                         <p class="image__error" style="color:red">{{ $errors->first('image') }}</p>

--- a/resources/views/tags/index.blade.php
+++ b/resources/views/tags/index.blade.php
@@ -4,7 +4,7 @@
             <form action={{ route('tags.index') }} method="POST">
                 <div class="flex items-center justify-between">
                     @csrf
-                    <input class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block" type="text" name="tag[tag]" placeholder="新しいタグ名を入力" value="{{ old('tag.tag')}}">
+                    <input class="border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm mt-1 block" type="text" name="tag[tag]" placeholder="新しいタグ名を入力" value="{{ old('tag.tag') }}">
                     <p class="tag__error" style="color:red">{{ $errors->first('tag.tag') }}</p>
                     <div class="inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
                         <input type="submit" value="保存する"/>

--- a/resources/views/testaments/show.blade.php
+++ b/resources/views/testaments/show.blade.php
@@ -14,7 +14,7 @@
                           </li>
                           <li class="flex items-center">
                             <span class="text-gray-600 hover:text-blue-500 transition-colors duration-300">
-                                <a href="/testaments/volume{{ $volume }}/chapter{{ $chapter }}">第{{ $chapter }}{{ $volume === '19' ? '篇' : '章' }}</a>
+                                <a href="/testaments/volume{{ $volume }}/chapter{{ $chapter }}">第{{ $chapter }}{{ $volume === 19 ? '篇' : '章' }}</a>
                             </span>
                           </li>
                         </ol>
@@ -27,7 +27,7 @@
                     <div class="p-6 text-gray-900">
                         <div class="mx-auto max-w-5xl lg:mx-0">
                           <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
-                              {{ $chapter_set->volume->title }}: 第{{ $chapter_set->chapter }}{{ $volume === '19' ? '篇' : '章' }}
+                              {{ $chapter_set->volume->title }}: 第{{ $chapter_set->chapter }}{{ $volume === 19 ? '篇' : '章' }}
                           </h2>
                           <div class="mt-2 text-lg leading-8 text-gray-600">
                               @foreach ($testaments as $testament)


### PR DESCRIPTION
## 概要
- バリデーションルールを修正・追加とエラーメッセージのフィールド名の追加
- ノートとコメントでの意図せず聖句が登録されているエラーを修正
- 友達リクエストを送信するリンクに送信済かどうか判定を加え、送信済みであればそれ以上リンクを押せないようにした
## 変更点
- バリデーション
  - タグにバリデーションルールを実装した。`TagRequest.php `を作成し、入力を必須にし、文字数を制限した。
  - ノートのtitleの文字数を制限した。またimageのデータサイズの桁を間違えていたので、2MBに修正した。
  - `validation.php`のattributeにタグ・ノート・コメントのフィールド名を追加した。
- 聖句のエラー
  - コメントのコントローラメソッドのプロパティ名を変更した。異なる処理に使用されるプロパティと同名のプロパティを使用していたため、予期せぬ挙動が起こっていた。
  - ノートに意図せず聖句が挿入されるエラーは、保存処理のエラーではなく、#41 におけるデータベース操作が原因だった。truncate()でレコードを削除する処理を関連する中間テーブルについて実行していなかったため、かつて存在していたノートのid に紐づいた聖句が表示されていた。
関連するテーブルを含めてtruncate()を実行し、意図せず聖句が表示されないことを確認した。
- 友達リクエスト
  - ユーザー一覧画面の友達リクエスト処理について、既にリクエストを送信している場合はリクエストを送信しないようにした。