### PR TITLE
feat: #53 introduce PhotoSwipe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,10 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "BibleStudyHub",
+            "dependencies": {
+                "photoswipe": "^5.4.3"
+            },
             "devDependencies": {
                 "@tailwindcss/forms": "^0.5.2",
                 "alpinejs": "^3.4.2",
@@ -877,9 +881,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.3",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-            "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
             "dev": true,
             "funding": [
                 {
@@ -1270,6 +1274,14 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
+        },
+        "node_modules/photoswipe": {
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/photoswipe/-/photoswipe-5.4.3.tgz",
+            "integrity": "sha512-9UC6oJBK4oXFZ5HcdlcvGkfEHsVrmE4csUdCQhEjHYb3PvPLO3PG7UhnPuOgjxwmhq5s17Un5NUdum01LgBDng==",
+            "engines": {
+                "node": ">= 0.12.0"
+            }
         },
         "node_modules/picocolors": {
             "version": "1.0.0",
@@ -1722,9 +1734,9 @@
             "dev": true
         },
         "node_modules/vite": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-            "integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+            "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.18.10",

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
         "postcss": "^8.4.6",
         "tailwindcss": "^3.1.0",
         "vite": "^4.0.0"
+    },
+    "dependencies": {
+        "photoswipe": "^5.4.3"
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,3 +5,30 @@ import Alpine from 'alpinejs';
 window.Alpine = Alpine;
 
 Alpine.start();
+
+/*global Image*/
+
+import PhotoSwipeLightbox from 'photoswipe/lightbox';
+import 'photoswipe/style.css';
+
+window.addEventListener('load', () => {
+  const gallery = document.querySelector('#photo-gallery');
+  if (!gallery) return; // #my-galleryが存在しない場合は何もしない
+
+  const photoswipe = new PhotoSwipeLightbox({
+    gallery: '#photo-gallery',
+    children: 'a',
+    showHideAnimationType: 'fade',
+    pswpModule: () => import('photoswipe')
+  });
+  photoswipe.init();
+
+  gallery.querySelectorAll('a').forEach(elem => {
+    const img = new Image();
+    img.src = elem.href;
+    img.onload = () => {
+      elem.dataset.pswpWidth = img.width;
+      elem.dataset.pswpHeight = img.height;
+    };
+  });
+});

--- a/resources/views/notes/show.blade.php
+++ b/resources/views/notes/show.blade.php
@@ -107,9 +107,11 @@
                         @endif
                         <p class="text-gray-700">{{ $note->text }}</p>
                         @if ($note->image_url)
-                        <ul class="mt-3 gap-4 md:gap-6 xl:gap-8 w-1/2">
+                        <ul id="photo-gallery" class="mt-3 gap-4 md:gap-6 xl:gap-8 w-1/2">
                             <li class="group flex justify-center items-center bg-gray-100 overflow-hidden rounded-lg shadow-lg relative">
-                                <img src="{{ $note->image_url }}" class="object-contain object-center group-hover:scale-105 transition duration-200"/>
+                                <a href="{{ $note->image_url }}">
+                                    <img src="{{ $note->image_url }}" class="object-contain object-center group-hover:scale-105 transition duration-200"/>
+                                </a>
                             </li>
                         </ul>
                         @endif


### PR DESCRIPTION
## 概要
#53 のために、[PhotoSwipe](https://photoswipe.com/)を導入した。
## 変更点
- npmでPhotoSwipeをインストールした。
- `resources/js/app.js`にコードを追記した。ブラウザにPhotoSwipeをロード・初期化し、PhotoSwipe Lightboxが正しく動作するためのデータを `<a>` 要素に追加する。
- `<ul>`要素にギャラリーのコンテナ要素を識別するためのIDを追加した