### PR TITLE
fix: #42 apply policies

### DIFF
--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\Comment;
 use App\Models\Testament;
+use App\Models\Note;
 use App\Http\Requests\CommentRequest;
 use Illuminate\Support\Facades\Auth;
 
@@ -13,8 +14,11 @@ class CommentController extends Controller
     /**
      * コメント一覧表示
      */
-    public function index($note, Comment $comment, Request $request)
+    public function index($note, Request $request)
     {
+        $note_model = Note::find($note); // ルートパラメータから受け取ったnoteのidで対応するノートを取得
+        $this->authorize('view', $note_model); // $note_modelに対応するNoteポリシーメソッドviewを呼び出す
+        
         if ($request->has('cancel_comment_take')) {
             // sessionからvolumeキー、chapterキーの値を取得
             $volumes = session('volume', []);
@@ -116,8 +120,6 @@ class CommentController extends Controller
         // セッション内のすべてのデータを取得する（デバック)
         $all_session_data = session()->all();
         
-        $user_id = Auth::id();
-        
         return view('notes.comments.index')->with([
             'note_id' => $note,
             'comments' => $comments,
@@ -125,7 +127,6 @@ class CommentController extends Controller
             'testaments_by_volume_and_chapter' => $testaments_by_volume_and_chapter,
             'last_selected_testament' => $last_selected_testament ?? null,
             'all_session_data' => $all_session_data,
-            'user_id' => $user_id,
             ]);
     }
      
@@ -177,6 +178,7 @@ class CommentController extends Controller
     public function edit($note, $comment, Request $request)
     {
         $edit_comment = Comment::find($comment);
+        $this->authorize('update', $edit_comment);
         
         if (session()->has('comment_creating')) {
             session()->forget('comment_creating');

--- a/app/Http/Controllers/NoteController.php
+++ b/app/Http/Controllers/NoteController.php
@@ -65,6 +65,8 @@ class NoteController extends Controller
      */
      public function show(Note $note)
      {
+         $this->authorize('view', $note);
+         
          // idを昇順で並べ替え
          $testaments_query_builder = $note->testaments->sortBy('id');
          
@@ -72,13 +74,10 @@ class NoteController extends Controller
          $testaments_by_volume_and_chapter = $testaments_query_builder->groupBy('volume_id')->map(function ($testaments) {
              return $testaments->groupBy('chapter');
          });
-         
-         $user_id = Auth::id();
         
          return view('notes.show')->with([
              'testaments_by_volume_and_chapter' => $testaments_by_volume_and_chapter,
              'note' => $note,
-             'user_id' => $user_id,
              ]);
      }
     
@@ -219,6 +218,8 @@ class NoteController extends Controller
       */
       public function edit(Note $note, Tag $tag, Request $request)
       {
+          $this->authorize('update', $note);
+          
           // sessionに編集中のデータがない場合の処理
           if (!session()->has('note_editing')) {
               // 編集するノートのtestamentsをsessionに保存する
@@ -343,6 +344,8 @@ class NoteController extends Controller
       */
       public function update(Note $note, NoteRequest $request)
       {
+          $this->authorize('update', $note);
+          
           $input_note = $request['note'];
           $input_testaments = $request->testaments_array;
           $input_tags = $request->tags_array;
@@ -394,6 +397,8 @@ class NoteController extends Controller
        */
        public function delete(Note $note)
        {
+           $this->authorize('delete', $note);
+           
            $note->delete(); // Modelクラスの関数delete
            return redirect(route('notes.index'));
        }

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -28,11 +28,15 @@ class TagController extends Controller
     
     public function edit(Tag $tag)
     {
+        $this->authorize('update', $tag);
+        
         return view('tags.edit')->with(['tag' => $tag]);
     }
     
     public function update(TagRequest $request, Tag $tag)
     {
+        $this->authorize('update', $tag);
+        
         $input_tag = $request['tag'];
         $input_tag += ['user_id' => $request->user()->id];
         
@@ -43,6 +47,8 @@ class TagController extends Controller
     
     public function delete(Tag $tag)
     {
+        $this->authorize('delete', $tag);
+        
         $tag->delete();
         return redirect(route('tags.index'));
     }

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Comment;
+use App\Models\User;
+use App\Models\Note;
+use App\Models\Connection;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\Response;
+
+class CommentPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Comment  $comment
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function update(User $user, Comment $comment): Response
+    {
+        // ユーザーがノートを編集・更新できるかどうか確認
+        return $user->id === $comment->user_id
+                    ? Response::allow()
+                    : Response::deny('申し訳ありませんが、このコメントを編集または更新する権限がありません。');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Comment  $comment
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function delete(User $user, Comment $comment): Response
+    {
+        // ユーザーがノートを削除できるかどうか確認
+        return $user->id === $comment->user_id
+                    ? Response::allow()
+                    : Response::deny('申し訳ありませんが、このコメントを削除する権限がありません。');
+    }
+}

--- a/app/Policies/NotePolicy.php
+++ b/app/Policies/NotePolicy.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Note;
+use App\Models\User;
+use App\Models\Connection;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\Response;
+
+class NotePolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Note  $note
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function view(User $user, Note $note): Response
+    {
+        $user_id = $user->id;
+        
+        // ユーザーがNoteを閲覧できるどうかを確認
+        if ($user_id === $note->user_id) {
+            return Response::allow();
+        }
+        
+        // 友達のidを取得
+        $friend_ids = Connection::where(function ($query) use ($user_id) {
+            $query->where('approval', 1)
+                  ->where(function ($query) use ($user_id) {
+                      $query->orWhere('follow_id', $user_id)
+                            ->orWhere('followed_id', $user_id);
+                  });
+        })->get()->flatMap(function ($record) use ($user_id) {
+            return [$record->follow_id, $record->followed_id];
+        })->reject(function ($friend_id) use ($user_id) {
+            return $friend_id == $user_id;
+        })->unique()->values()->toArray();
+        
+        // $noteが友人のもので、かつ公開ノートであるかどうか確認
+        if (in_array($note->user_id, $friend_ids)) {
+            if ($note->public === 1) {
+                return Response::allow();
+            }
+        }
+        
+        return Response::deny('申し訳ありませんが、このノート及びコメントを閲覧する権限がありません。');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Note  $note
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function update(User $user, Note $note): Response
+    {
+        // ユーザーがノートを編集・更新できるかどうか確認
+        return $user->id === $note->user_id
+                    ? Response::allow()
+                    : Response::deny('申し訳ありませんが、このノートを編集または更新する権限がありません。');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Note  $note
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function delete(User $user, Note $note): Response
+    {
+        // ユーザーがノートを削除できるかどうか確認
+        return $user->id === $note->user_id
+                    ? Response::allow()
+                    : Response::deny('申し訳ありませんが、このノートを削除する権限がありません。');
+    }
+}

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Auth\Access\Response;
+
+class TagPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Tag  $tag
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function update(User $user, Tag $tag): Response
+    {
+        // ユーザーがタグを編集・更新できるかどうか確認
+        return $user->id === $tag->user_id
+                    ? Response::allow()
+                    : Response::deny('申し訳ありませんが、このタグを編集または更新する権限がありません。');
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param  \App\Models\User  $user
+     * @param  \App\Models\Tag  $tag
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function delete(User $user, Tag $tag): Response
+    {
+        // ユーザーがタグを編集・更新できるかどうか確認
+        return $user->id === $tag->user_id
+                    ? Response::allow()
+                    : Response::deny('申し訳ありませんが、このタグを削除する権限がありません。');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,6 +3,12 @@
 namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
+use App\Models\Note;
+use App\Models\Comment;
+use App\Models\Tag;
+use App\Policies\NotePolicy;
+use App\Policies\CommentPolicy;
+use App\Policies\TagPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -14,6 +20,9 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         // 'App\Models\Model' => 'App\Policies\ModelPolicy',
+        Note::class => NotePolicy::class,
+        Comment::class => CommentPolicy::class,
+        Tag::class => TagPolicy::class,
     ];
 
     /**

--- a/resources/views/notes/comments/index.blade.php
+++ b/resources/views/notes/comments/index.blade.php
@@ -20,7 +20,7 @@
                                         </p>
                                     </div>
                                     <div>
-                                        @if ($comment->user_id === $user_id)
+                                        @can ('update', $comment)
                                         <x-dropdown align="light">
                                             <x-slot name="trigger" class="relative z-60">
                                                 <button>
@@ -40,7 +40,7 @@
                                                 </x-dropdown-link>
                                             </x-slot>
                                         </x-dropdown>
-                                        @endif
+                                        @endcan
                                     </div>
                                 </div>
                                 <div class="p-5">

--- a/resources/views/notes/index.blade.php
+++ b/resources/views/notes/index.blade.php
@@ -74,7 +74,7 @@
                                                             </x-slot>
                                                             <x-slot name="content">
                                                                 <x-dropdown-link href="/notes/{{ $note->id }}/comments">コメントする</x-dropdown-link>
-                                                                @if ($note->user_id === $user_id)
+                                                                @can ('update', $note)
                                                                 <x-dropdown-link href="/notes/{{ $note->id }}/edit">編集する</x-dropdown-link>
                                                                 <x-dropdown-link>
                                                                     <form action="/notes/{{ $note->id }}" id="form_{{ $note->id }}" method="post">
@@ -83,7 +83,7 @@
                                                                         <button type="button" onclick="deleteNote({{ $note->id }})">このノートを削除する</button>
                                                                     </form>
                                                                 </x-dropdown-link>
-                                                                @endif
+                                                                @endcan
                                                             </x-slot>
                                                         </x-dropdown>
                                                     </div>

--- a/resources/views/notes/show.blade.php
+++ b/resources/views/notes/show.blade.php
@@ -62,7 +62,7 @@
                                                 </x-slot>
                                                 <x-slot name="content">
                                                     <x-dropdown-link href="/notes/{{ $note->id }}/comments">コメントする</x-dropdown-link>
-                                                    @if ($note->user_id === $user_id)
+                                                    @can ('update', $note)
                                                     <x-dropdown-link href="/notes/{{ $note->id }}/edit">編集する</x-dropdown-link>
                                                     <x-dropdown-link>
                                                         <form action="/notes/{{ $note->id }}" id="form_{{ $note->id }}" method="post">
@@ -71,7 +71,7 @@
                                                             <button type="button" onclick="deleteNote({{ $note->id }})">このノートを削除する</button>
                                                         </form>
                                                     </x-dropdown-link>
-                                                    @endif
+                                                    @endcan
                                                 </x-slot>
                                             </x-dropdown>
                                         </div>

--- a/resources/views/tags/index.blade.php
+++ b/resources/views/tags/index.blade.php
@@ -20,7 +20,7 @@
                                     <div class="tags">
                                         <a href="/notes?tag={{ $tag->id }}">{{ $tag->tag }}</a>
                                     </div>
-                                    @if ($tag->user_id === $user_id)
+                                    @can ('update', $tag)
                                     <x-dropdown align="light">
                                         <x-slot name="trigger" class="relative z-60">
                                             <button>
@@ -40,7 +40,7 @@
                                             </x-dropdown-link>
                                         </x-slot>
                                     </x-dropdown>
-                                    @endif
+                                    @endcan
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## 概要
- ポリシーを作成、適用して、ノートモデル・コメントモデル・タグモデルに対してアクセス権を設定した。
## 変更点
- ポリシーを作成。(`NotePolicy`,`CommentPolicy`,`TagPolicy`)
- ポリシーを設定した。
  - 特定のノート及びコメントの閲覧については、ログインユーザーノートあるいはログインユーザーの友達の公開ノートであれば閲覧を認可する。
  - ノート・コメント・タグの編集・削除については、ログインユーザーであれば処理を認可する。
  - 認可されなかった場合表示される403エラーのページを日本語でカスタマイズした。
- ポリシーを使用できるよう、`app/Providers/AuthServiceProvider.php`に作成したポリシーを登録した。
- ポリシーを使用するため、コントローラメソッドに`authorize()`メソッドを追加。対応するポリシーメソッドを実行する。
  - ※`CommentController`の`index`メソッドについて、`NotePolicy`の`view`メソッドを実行するよう設定している。コントローラメソッドの受け取るルートパラメータ$noteを使って認可する必要があったため。
- アクセス権があるかないかでビューの表示を切り替えるため、`@can`ディレクティブをビューに適用。前に判定に使っていた$user_idをメソッドから削除した。
## 以下の記事を参考にさせていただきました。
(https://zenn.dev/redheadchloe/articles/d60fd178757e96#can%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89)
(https://readouble.com/laravel/9.x/ja/authorization.html#intercepting-gate-checks)